### PR TITLE
Invite-based registration: link-only sign-up, hashed single-use tokens, and SMTP

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,3 +50,54 @@ MAX_INFLIGHT_UPLOAD_MB_PER_USER=2048
 # likes and choose which rate-limit bucket it is charged under. When unsure, set
 # it too low: the cost is a shared bucket, not a bypassable one.
 TRUSTED_PROXY_COUNT=1
+
+# ── Mail & invites ────────────────────────────────────────────────────────────
+# See docs/configuration.md for the full reference, including the Gmail profile.
+
+# The canonical external origin invite links are built from. Deliberately NOT
+# derived from the request's Host header: behind Cloudflare -> nginx an
+# attacker-controlled Host on the add-email request could otherwise steer an
+# invite link at a domain they own. No trailing slash. Required once SMTP is set;
+# the app refuses to boot without it.
+PUBLIC_BASE_URL=https://photos.example.com
+
+# false -> nothing is sent. Invites are still issued, and an admin can still hand
+# the link over with the copy-link button; only delivery stops.
+MAIL_ENABLED=true
+
+# Leave SMTP_HOST empty to run without a relay: invite emails are then printed to
+# the application log, link included, which is what a dev checkout wants.
+SMTP_HOST=
+SMTP_PORT=587
+SMTP_USERNAME=
+SMTP_PASSWORD=
+
+# starttls (587, upgrade in band) | ssl (465, TLS from the first byte) | none.
+# 'none' sends credentials in the clear — only defensible for a relay on localhost.
+SMTP_SECURITY=starttls
+
+# Envelope and header sender. With Gmail this MUST be the SMTP_USERNAME account:
+# Google rewrites a From address it does not own, so anything else silently
+# becomes the account address anyway.
+MAIL_FROM=
+MAIL_FROM_NAME=PixelVault
+
+# Socket timeout for the whole SMTP conversation. Sends run synchronously inside
+# the admin's request and the server has 8 threads total, so an unbounded send
+# against a relay that accepts the connection and goes quiet holds an eighth of
+# the server until the kernel gives up.
+MAIL_TIMEOUT_SECONDS=10
+
+# Address shown to share-link guests who have no account, so they know who to ask
+# for an invitation. Defaults to MAIL_FROM.
+ADMIN_CONTACT=
+
+# How long an invite link stays usable, from issue or resend. Longer is friendlier
+# to someone who checks mail weekly; it is also longer for a link sitting in a
+# forwarded email or a compromised mailbox to be usable by someone else.
+INVITE_TTL_HOURS=72
+
+# Minimum gap between two sends of the same invite. Not politeness: without it the
+# resend button is a mail-bomb aimed at whatever address was typed in, and the
+# sending domain's reputation with the relay pays for it.
+INVITE_RESEND_COOLDOWN_SECONDS=60

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 
 ## Improvements
 
+- **Invite-based registration** ([#7](https://github.com/gfvandehei/PixelVault/issues/7)): registration is now link-only. Adding an address in the admin panel mints a single-use, expiring invitation and emails it automatically; the recipient clicks through to a form with their address filled in and locked, picks a username and password, and is signed in. The public sign-up page is gone — `/register` no longer exists.
+- **Invite management in the admin panel**: every authorized address now shows its state (sent, not emailed, expired, send failed, accepted, or a pre-invite legacy row), when it was last sent and when it expires, plus **Resend** and **Copy link** actions. Copy link works with no mail relay at all, so SMTP is optional rather than a hard dependency of registration.
+- **Outbound email**: the app can now send mail over SMTP, configured entirely through environment variables (`SMTP_HOST`, `SMTP_SECURITY`, `MAIL_FROM`, and friends — see `docs/configuration.md` §5). With no relay configured, invitations are printed to the application log instead, so a fresh checkout can complete the flow without one.
+- **Guests without accounts get an answer**: the Access Required page a share-link visitor lands on now names who to ask for an invitation (`ADMIN_CONTACT`), instead of pointing at a sign-up page that no longer exists.
+
 - **Client-side photo caching**: Images viewed in the lightbox are now cached in memory for the duration of the session, eliminating re-fetches when navigating back to previously viewed photos.
 - **HTTP cache headers**: Media endpoints now respond with `Cache-Control: private, max-age=31536000, immutable`, allowing the browser to cache photos and thumbnails across page loads without re-validating.
 - **Expanded preload window**: The lightbox preloads 2 images in both directions (previously only forward), so backward navigation is as fast as forward.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,8 @@
 
 PixelVault is an invite-only, self-hosted photo album sharing application. Users upload photos/videos into named albums, then share albums via two link types: an upload link (guests can browse & upload) and a view-only link. Built with Flask + SQLite + Nginx, packaged for Docker deployment.
 
+Accounts exist only by invitation: an admin adds an address, the app emails a single-use link, and following that link is the only way to register. There is no public sign-up page.
+
 ---
 
 ## Tech Stack
@@ -33,21 +35,28 @@ pixelvault/
 ├── src/pixelvault/
 │   ├── __init__.py                 # App factory (create_app), migrations, CLI, error handlers
 │   ├── config.py                   # Env var loading & validation
-│   ├── extensions.py               # db, login_manager, limiter — initialized separately to avoid circular imports
+│   ├── extensions.py               # db, login_manager, limiter, mailer — initialized separately to avoid circular imports
 │   ├── models.py                   # SQLAlchemy models: User, Album, Photo, AllowedEmail
 │   ├── utils.py                    # File handling, ZIP building, shared decorators
 │   ├── uploads.py                  # Chunked upload sessions: quotas, chunk append, TTL sweep
+│   ├── mailer.py                   # SMTP transport only — knows nothing about invites
+│   ├── emails.py                   # Message content: renders the invite email from templates
+│   ├── invites.py                  # Invite lifecycle: issue, rotate, validate, consume
 │   └── routes/
 │       ├── __init__.py             # Registers all route blueprints via register(app)
-│       ├── auth.py                 # /register, /login, /logout
+│       ├── auth.py                 # /login, /logout, /invite/* (registration is invite-only)
 │       ├── albums.py               # /dashboard, /album/* (CRUD, settings, ZIP download)
 │       ├── share.py                # /share/<token> and /view/<view_token> (public links)
 │       ├── media.py                # /media/<filename> (authenticated file serving)
 │       ├── api.py                  # /api/* (JSON photo lists for gallery JS)
-│       └── admin.py                # /admin (allowed emails, user list)
+│       └── admin.py                # /admin (invites, user list, album list)
 ├── templates/                      # Jinja2 HTML (base.html + 8 pages)
+│   └── email/                      # invite.txt / invite.html — the invitation's two parts
 ├── docs/
+│   ├── configuration.md            # Every environment variable, why it exists, how to set it
 │   ├── database_schema.md          # Table/column reference
+│   ├── registration_invites.md     # Operator guide: inviting, resending, troubleshooting mail
+│   ├── invite_registration_design.md  # Architectural design for the invite system (#7)
 │   ├── upload_protocol.md          # Chunked upload wire contract (client <-> server)
 │   ├── upload_client.md            # Client-side uploader internals
 │   └── upload_operations.md        # Deployment, per-hop limits, troubleshooting, tuning
@@ -101,6 +110,10 @@ export UPLOAD_FOLDER=/path/to/uploads
 docker compose -f ./docker/test.docker-compose.yml up
 ```
 
+The test container has no SMTP relay, so invitations are printed to the log by `ConsoleMailer`.
+To exercise registration: log in as the seeded admin, add an address in `/admin`, then copy the
+invite link out of `docker compose logs` and open it.
+
 **Production:**
 ```bash
 # 1. Get SSL certs
@@ -133,8 +146,21 @@ docker compose -f ./docker/prod.docker-compose.yml --env-file .env.prod up -d --
 | `MAX_CONCURRENT_UPLOADS_PER_USER` | `10` | no | Open upload sessions one user may hold at once; enforced at `init` |
 | `MAX_INFLIGHT_UPLOAD_MB_PER_USER` | `2048` | no | Total declared bytes across a user's open sessions, in MB. Read into `MAX_INFLIGHT_UPLOAD_BYTES_PER_USER` |
 | `TRUSTED_PROXY_COUNT` | `1` | no | Proxies appending to `X-Forwarded-For` ahead of Flask; consumed by `ProxyFix`. **Setting it too high lets clients spoof their rate-limit identity** — when unsure, set it too low |
+| `PUBLIC_BASE_URL` | — | **once SMTP is set** | Canonical external origin invite links are built from, e.g. `https://photos.example.com`. Configured rather than derived from the request, so a spoofed `Host` cannot point an invite at another domain |
+| `MAIL_ENABLED` | `true` | no | `false` → `NullMailer`; invites are still issued and still usable via the admin copy-link button |
+| `SMTP_HOST` | — | no | Unset → `ConsoleMailer`, which prints the whole invitation to the log. That is the dev default |
+| `SMTP_PORT` | `587` | no | 587 pairs with `starttls`, 465 with `ssl` |
+| `SMTP_USERNAME` / `SMTP_PASSWORD` | — | no | Blank = unauthenticated relay. The password is **not** stripped — Gmail app passwords are pasted with spaces |
+| `SMTP_SECURITY` | `starttls` | no | `starttls` \| `ssl` \| `none` |
+| `MAIL_FROM` | — | **once SMTP is set** | Envelope and header sender. With Gmail this must be the `SMTP_USERNAME` account |
+| `MAIL_FROM_NAME` | `PixelVault` | no | Display name |
+| `MAIL_TIMEOUT_SECONDS` | `10` | no | Socket timeout. Sends are synchronous inside the admin request, so this bounds how long one of 8 threads is held by a dead relay |
+| `ADMIN_CONTACT` | falls back to `MAIL_FROM` | no | Address shown to accountless share-link guests on `request_permission.html` |
+| `INVITE_TTL_HOURS` | `72` | no | Invite link lifetime, measured from issue or rotation |
+| `INVITE_RESEND_COOLDOWN_SECONDS` | `60` | no | Minimum gap between two sends of one invite. Not politeness: an unthrottled resend button is a mail-bomb primitive |
 
-The last five are documented in depth in [docs/upload_operations.md](docs/upload_operations.md).
+The upload five are documented in depth in [docs/upload_operations.md](docs/upload_operations.md);
+**every** variable, with its reasoning, is in [docs/configuration.md](docs/configuration.md).
 
 ---
 
@@ -173,6 +199,41 @@ from the routes. The `upload_session` table is created by `_run_migrations()` on
 step. Abandoned partials are swept opportunistically inside `init` and on demand via
 `flask cleanup-uploads`.
 
+### Invite-Based Registration
+There is no public sign-up. `/register` does not exist; an account can only be created by
+following an emailed, single-use link. Adding an address in `/admin` mints a token, commits the
+row, and *then* sends — so a relay outage leaves a resendable invite rather than nothing.
+
+`AllowedEmail` is no longer a passive whitelist: one row is both the assertion that an address
+may register and the credential that carries that permission, so it has a lifecycle
+(`state` is a derived property, never a column — see [docs/database_schema.md](docs/database_schema.md)).
+
+Three modules, three concerns, deliberately not one:
+- [mailer.py](src/pixelvault/mailer.py) — transport. Has never heard of invites, so the next
+  feature needing email is free and a relay migration is one config change.
+- [emails.py](src/pixelvault/emails.py) — content. Renders the invitation's text and HTML parts.
+- [invites.py](src/pixelvault/invites.py) — lifecycle. No Flask imports; testable without a client.
+
+Load-bearing rules, in decreasing order of how badly breaking them hurts:
+- **The email address comes from the invite row, never from the form.** The acceptance form's
+  email field has no `name` attribute and `invites.consume` reads the address off the row.
+  Otherwise the holder of a link for one address could register as another and the whitelist
+  means nothing.
+- **Tokens are hashed at rest** (SHA-256 of `secrets.token_urlsafe(32)`). The plaintext exists
+  only in the sent email and one flash. A link can therefore never be re-shown — renewal
+  *mints*, which is why resend and copy-link both kill the previous link.
+- **`rotate` is the only renewal path.** Resend, copy-link, and *Send invite* on a legacy row
+  all call it; `issue` is strictly for an address never seen before.
+- **`mark_sent` is owned by `emails.send_invite`**, called on both outcomes. Routes never call
+  it, or `send_count` double-counts.
+- **The token leaves the URL immediately.** `/invite/<token>` validates, stashes the token in
+  the signed session, and redirects to `/invite` — keeping a bearer credential out of nginx
+  access logs and browser history.
+
+Operator guide (setup, the panel's buttons, mail troubleshooting):
+[docs/registration_invites.md](docs/registration_invites.md). Design and rationale:
+[docs/invite_registration_design.md](docs/invite_registration_design.md).
+
 ### Share Link System
 Each `Album` has two tokens:
 - `token` → `/share/<token>` — upload link (guests can browse & upload)
@@ -183,11 +244,15 @@ Both links respect the album-level `allow_upload` toggle.
 ### Rate Limits (Flask-Limiter)
 | Endpoint | Limit |
 |---|---|
-| Register | 10/hour |
 | Login | 20/hour |
+| Invite link click (`GET /invite/<token>`) | 60/hour (per IP) |
+| Invite form (`GET /invite`) | 60/hour (per IP) |
+| Invite submit (`POST /invite`) | 20/hour (per IP) |
 | Upload (legacy single-request) | 600/hour |
 | Album create | 30/hour |
-| Admin email add | 60/hour |
+| Admin email add (issues + sends an invite) | 60/hour |
+| Admin invite resend | 30/hour |
+| Admin invite copy-link | 30/hour |
 | Chunked `init` | 120/hour |
 | Chunked `status` | 300/hour |
 | Chunked `chunk` | 600/hour, **charged only on non-200** |
@@ -203,7 +268,19 @@ spent on failures would start rejecting the good chunks too.
 
 ## Security Notes
 
-- Registration is **invite-only**: admins add emails to `AllowedEmail` before users can register.
+- Registration is **invite-only and link-only**: there is no `/register`. An admin issues an
+  invite, the app emails a single-use TTL-bounded link, and accepting it is the only way an
+  account is created.
+- The registering email address is read from the invite row, never from the submitted form —
+  the single highest-value line in the feature.
+- Invite tokens are **hashed at rest**, so neither a database backup nor a screenshot of the
+  admin panel holds a working account-creation credential.
+- Invites are single-use (consumption nulls the token hash in the same transaction as user
+  creation) and expire on their own after `INVITE_TTL_HOURS`.
+- Resends are cooldown-gated so the app cannot be used as a mail-bomb relay against a
+  third-party address. Copy-link is exempt because it sends nothing.
+- Invite links are built from `PUBLIC_BASE_URL`, never from the request's `Host`.
+- Accepting an invite while already signed in is refused, not silently merged.
 - Sessions use `HttpOnly=True`, `SameSite=Lax`, and `Secure=True` when `HTTPS=true`.
 - Security headers set on every response: `X-Frame-Options`, `X-Content-Type-Options`, HSTS.
 - bcrypt uses 600,000 rounds — password operations are intentionally slow.
@@ -221,7 +298,7 @@ spent on failures would start rejecting the good chunks too.
 | Model | Key Fields |
 |---|---|
 | `User` | `username`, `email`, `password_hash`, `is_admin` |
-| `AllowedEmail` | `email` (whitelist for registration) |
+| `AllowedEmail` | `email`, `token_hash` (SHA-256; the plaintext is never stored), `token_issued_at`, `expires_at`, `last_sent_at`, `send_count`, `last_send_error`, `accepted_at`, `accepted_user_id`, `note`, `prefill_username`, `invited_by_id` — one row is both the whitelist entry and the invite credential. `state` and `is_pending` are **derived properties**, never columns |
 | `Album` | `name`, `token`, `view_token`, `allow_upload`, `owner_id` |
 | `Photo` | `stored_filename` (UUID), `original_filename`, `mime_type`, `album_id`, `uploader_id`, `is_thumbnail` |
 | `UploadSession` | `upload_id` (UUID, the resume handle), `client_key`, `total_size`, `received_bytes`, `album_id`, `user_id`, `updated_at` — unique on `(user_id, album_id, client_key)` |
@@ -250,11 +327,20 @@ spent on failures would start rejecting the good chunks too.
 | `test_upload_access.py` | Cross-user isolation, revoked `allow_upload`, anonymous callers |
 | `test_upload_recovery.py` | TTL sweep, orphaned partials, quota reclamation |
 | `test_upload_security.py` | Decompression-bomb ceiling and the MIME-not-extension path choice |
+| `test_mailer.py` | Backend selection from config, timeout application, `MailError` on refusal, `MemoryMailer` capture |
+| `test_invite_model.py` | The six-state `state` property, its evaluation order, and the migration's effect on pre-existing rows |
+| `test_invite_lifecycle.py` | Issue → send → accept, single use, rotation killing the old link, TTL expiry, resend cooldown |
+| `test_invite_email.py` | The composed invitation: both parts, the link's origin, refusal to compose without `PUBLIC_BASE_URL` |
+| `test_invite_admin.py` | The panel's four actions, the issue-commit-then-send order, and what each failure flashes |
+| `test_invite_access.py` | **The email cannot be overridden via the form**; bad/expired/replayed tokens; accepting while signed in; `/register` is gone; rate limits |
 
 `conftest.py` sets the environment before importing the app, because `config.py` reads
-env vars at module import time.
+env vars at module import time — which is why the invite TTL and resend cooldown are chosen
+there and not inside a test. A `mailer` fixture swaps a `MemoryMailer` into
+`app.extensions['mailer']`, so every test asserts on what *would* have been sent, with no
+network and no monkeypatched module globals.
 
-Coverage is upload-focused; the rest of the app is still verified manually via the
+Coverage is upload- and invite-focused; the rest of the app is still verified manually via the
 Docker test container. See [#25](https://github.com/gfvandehei/PixelVault/issues/25).
 
 ---

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A self-hosted photo and video sharing platform. Create albums, share links, and 
 
 ## Features
 
-- **Account system** — Invite-only registration with bcrypt-hashed passwords
+- **Account system** — Invite-only: an admin issues an invitation, the app emails a single-use link, and that link is the only way to register. bcrypt-hashed passwords
 - **Albums** — Create named albums with descriptions
 - **Upload links** — Share a link that lets others upload to your album
 - **View-only links** — Share a separate read-only link for browsing without upload access
@@ -51,7 +51,7 @@ python3 -c "import secrets; print(secrets.token_hex(32))"
 
 ### 4. Create the admin account
 
-Registration is invite-only — only emails the admin has authorized can sign up. You must create the admin account first.
+Registration is invite-only and there is no sign-up page, so the first account has to be created from the command line.
 
 **Option A — standalone script (recommended):**
 ```bash
@@ -74,7 +74,20 @@ This only needs to be done once. If an admin already exists the command will do 
 python app.py
 ```
 
-Visit http://localhost:5000, log in as admin, and go to **Admin** in the nav to authorize email addresses before sharing the registration link.
+Visit http://localhost:5000 and log in as admin.
+
+### 6. Invite someone
+
+Go to **Admin** in the nav and add an email address. That mints a single-use invitation link and
+emails it; the recipient clicks it, picks a username and password, and is in. Nobody can register
+any other way.
+
+With no `SMTP_HOST` set, the invitation is printed to the application log instead of sent — copy
+the link out of the log and hand it over. To send real mail, set `PUBLIC_BASE_URL`, `SMTP_HOST`
+and `MAIL_FROM`; see [docs/configuration.md §5](docs/configuration.md#5-mail--invites) for the
+full list (the Gmail app-password profile is there too) and
+[docs/registration_invites.md](docs/registration_invites.md) for the operator guide — resending,
+the copy-link fallback, and what to do when mail does not arrive.
 
 ---
 
@@ -161,9 +174,22 @@ files in `UPLOAD_CHUNK_SIZE` slices specifically to stay under that ceiling; set
 | `MAX_CONCURRENT_UPLOADS_PER_USER` | `10` | Open upload sessions one user may hold at once |
 | `MAX_INFLIGHT_UPLOAD_MB_PER_USER` | `2048` | Total size, in MB, of one user's in-progress uploads. Bounds disk held by abandoned partials |
 | `TRUSTED_PROXY_COUNT` | `1` | Number of reverse proxies in front of the app that append to `X-Forwarded-For`. **Setting it higher than the true count lets clients spoof their IP** — when unsure, set it lower |
+| `PUBLIC_BASE_URL` | — | External origin invite links are built from, e.g. `https://photos.example.com`. Required once SMTP is configured |
+| `MAIL_ENABLED` | `true` | Set `false` to stop sending entirely; invites are still issued and can be handed over with the admin copy-link button |
+| `SMTP_HOST` | — | Leave empty to print invitations to the log instead of sending them |
+| `SMTP_PORT` | `587` | 587 with `starttls`, 465 with `ssl` |
+| `SMTP_USERNAME` / `SMTP_PASSWORD` | — | Leave both empty for an unauthenticated relay |
+| `SMTP_SECURITY` | `starttls` | `starttls`, `ssl`, or `none` |
+| `MAIL_FROM` | — | Sender address. Required once SMTP is configured |
+| `MAIL_FROM_NAME` | `PixelVault` | Sender display name |
+| `MAIL_TIMEOUT_SECONDS` | `10` | Socket timeout for the SMTP conversation |
+| `ADMIN_CONTACT` | `MAIL_FROM` | Address shown to accountless guests who follow a share link |
+| `INVITE_TTL_HOURS` | `72` | How long an invitation link stays valid |
+| `INVITE_RESEND_COOLDOWN_SECONDS` | `60` | Minimum gap between two sends of one invitation |
 
-See [docs/upload_operations.md](docs/upload_operations.md) for how to tune the upload variables and
-for a per-hop map of every limit an upload passes through.
+See [docs/configuration.md](docs/configuration.md) for every variable with its reasoning,
+and [docs/upload_operations.md](docs/upload_operations.md) for how to tune the upload variables
+and a per-hop map of every limit an upload passes through.
 
 ---
 
@@ -173,7 +199,11 @@ PixelVault is designed with internet exposure in mind:
 
 | Threat | Mitigation |
 |--------|-----------|
-| Unauthorized registration | Invite-only — admin must authorize each email before registration is allowed |
+| Unauthorized registration | No public sign-up. Accounts are created only by following a single-use, expiring invitation link an admin issued for that specific address |
+| Registering under someone else's address | The address is read from the invite record on the server, never from the submitted form |
+| Leaked database or backup | Invitation tokens are stored only as SHA-256 hashes — the plaintext link is never persisted |
+| Replayed or stale invitation links | Single-use (consumed in the same transaction as account creation) and expiring after `INVITE_TTL_HOURS` |
+| Using the invite mailer to spam a third party | Per-invite resend cooldown plus a 30/hour limit on the admin resend action |
 | Weak passwords | Minimum 8 chars, bcrypt with 600,000 rounds |
 | Brute force | Flask-Limiter: 20 login attempts/hour per IP |
 | File upload attacks | Extension whitelist + magic-byte MIME verification |
@@ -214,28 +244,32 @@ pixelvault/
 ├── src/pixelvault/           # Application package
 │   ├── __init__.py           # create_app() factory, DB migrations, error handlers, CLI
 │   ├── config.py             # Env-var config, allowed file types, validation constants
-│   ├── extensions.py         # db, login_manager, limiter instances
+│   ├── extensions.py         # db, login_manager, limiter, mailer instances
 │   ├── models.py             # User, AllowedEmail, Album, Photo (vanilla SQLAlchemy)
 │   ├── utils.py              # File handling, ZIP building, admin_required decorator
 │   ├── uploads.py            # Chunked upload sessions: quotas, chunk append, TTL sweep
+│   ├── mailer.py             # SMTP transport (and console/null/memory backends)
+│   ├── emails.py             # Renders the invitation message
+│   ├── invites.py            # Invite lifecycle: issue, rotate, validate, consume
 │   └── routes/
-│       ├── auth.py           # Register, login, logout
+│       ├── auth.py           # Login, logout, invitation acceptance
 │       ├── albums.py         # Dashboard, create/view/delete album, download
 │       ├── share.py          # Upload link, view-only link, file upload handler
 │       ├── media.py          # Authenticated media serving
 │       ├── api.py            # JSON photo list endpoints for gallery JS
-│       └── admin.py          # Admin panel — allowed emails and user list
+│       └── admin.py          # Admin panel — invites, users, albums
 ├── templates/
 │   ├── base.html             # Base layout + nav
 │   ├── login.html
-│   ├── register.html
+│   ├── register.html         # Invitation acceptance form
+│   ├── email/                # invite.txt / invite.html — the invitation message
 │   ├── dashboard.html        # Album list (owned + contributed)
 │   ├── create_album.html
 │   ├── album_view.html       # Owner's gallery view with share links
 │   ├── album_upload.html     # Share page (upload or view-only depending on link)
 │   ├── admin.html            # Admin panel
 │   └── error.html
-├── docs/                     # Upload protocol, client, and operations references
+├── docs/                     # Configuration, invites, database schema, upload references
 ├── uploads/                  # Created at runtime
 │   └── partials/             # In-progress chunked uploads (transient — exclude from backups)
 └── instance/                 # SQLite database (created at runtime)

--- a/docker/prod.docker-compose.yml
+++ b/docker/prod.docker-compose.yml
@@ -14,6 +14,25 @@ services:
       - DATABASE_URL=sqlite:////app/instance/pixelvault.db
       - MAX_UPLOAD_MB=${MAX_UPLOAD_MB:-500}
       - FLASK_DEBUG=false
+      # Mail & invites (docs/configuration.md §5, docs/registration_invites.md).
+      # Enumerated explicitly, like everything above: this list *is* the container's
+      # environment, so a variable missing here is silently absent in production no
+      # matter what .env.prod says. PUBLIC_BASE_URL is not optional once SMTP_HOST
+      # is set — create_app() refuses to boot without it, because it is the only
+      # source of the origin invite links point at.
+      - PUBLIC_BASE_URL=${PUBLIC_BASE_URL:-}
+      - MAIL_ENABLED=${MAIL_ENABLED:-true}
+      - SMTP_HOST=${SMTP_HOST:-}
+      - SMTP_PORT=${SMTP_PORT:-587}
+      - SMTP_USERNAME=${SMTP_USERNAME:-}
+      - SMTP_PASSWORD=${SMTP_PASSWORD:-}
+      - SMTP_SECURITY=${SMTP_SECURITY:-starttls}
+      - MAIL_FROM=${MAIL_FROM:-}
+      - MAIL_FROM_NAME=${MAIL_FROM_NAME:-PixelVault}
+      - MAIL_TIMEOUT_SECONDS=${MAIL_TIMEOUT_SECONDS:-10}
+      - ADMIN_CONTACT=${ADMIN_CONTACT:-}
+      - INVITE_TTL_HOURS=${INVITE_TTL_HOURS:-72}
+      - INVITE_RESEND_COOLDOWN_SECONDS=${INVITE_RESEND_COOLDOWN_SECONDS:-60}
     volumes:
       - ${UPLOAD_FOLDER:?UPLOAD_FOLDER not set}:/app/uploads
       - ${DATABASE_PATH:?DATABASE_PATH not set}:/app/instance

--- a/docker/test.docker-compose.yml
+++ b/docker/test.docker-compose.yml
@@ -21,6 +21,20 @@ services:
       - ADMIN_EMAIL=admin@test.com
       - ADMIN_USERNAME=admin
       - ADMIN_PASSWORD=password
+      # Invites, with no relay. SMTP_HOST is left unset on purpose, so build_mailer()
+      # picks ConsoleMailer and the whole invitation — link included — is printed to
+      # `docker compose logs`. That is how you walk the accept flow in this container:
+      # add an address in /admin, copy the link out of the log, open it.
+      # PUBLIC_BASE_URL still has to be set, since it is the only source of the link's
+      # origin, and it must match the port published below or the link will not open.
+      - PUBLIC_BASE_URL=http://localhost:5050
+      - ADMIN_CONTACT=admin@test.com
+      # Short enough to watch a link expire without waiting three days, long enough
+      # that a normal walkthrough does not trip over it.
+      - INVITE_TTL_HOURS=1
+      # The resend cooldown is a mail-bomb guard, and this container mails nobody —
+      # a 60s wait here only gets in the way of testing the button.
+      - INVITE_RESEND_COOLDOWN_SECONDS=5
     volumes:
       - ${PIXELVAULT_ROOT:?set the root}/src/pixelvault:/app/pixelvault
       - ${PIXELVAULT_ROOT:?set the root}/templates:/app/templates

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,377 @@
+# Configuration Reference
+
+Every environment variable PixelVault reads, what it does, and **what actually goes wrong when it
+is set badly**. This is the complete list — if a variable is not here, the application does not
+read it.
+
+Configuration is loaded once, at import, by [`src/pixelvault/config.py`](../src/pixelvault/config.py).
+Nothing re-reads the environment later, so **every change here needs a restart**, and a value that
+is wrong is wrong for the life of the process rather than for one request.
+
+Related documents:
+
+- [`.env.example`](../.env.example) — a copy-and-fill template of the same variables.
+- [`upload_operations.md`](upload_operations.md) — how the upload settings behave under load, and
+  the per-hop limits (Cloudflare, nginx, Gunicorn) they have to agree with.
+- [`upload_protocol.md`](upload_protocol.md) — the wire contract `UPLOAD_CHUNK_SIZE` feeds into.
+
+---
+
+## 1. How settings are loaded
+
+```
+.env / .env.prod / compose environment:  →  os.environ  →  config.py (import time)  →  app.config
+```
+
+Three consequences worth knowing before you debug a setting that "isn't taking effect":
+
+1. **The compose files enumerate variables explicitly.** A variable added to `.env.prod` but not
+   listed in `docker/prod.docker-compose.yml` never reaches the container. This is the most common
+   way a correct value has no effect in production.
+2. **`config.py` binds module-level constants at import.** Some are captured further still — as
+   default argument values, or copied into `app.config` — so nothing short of a restart moves them.
+3. **Unset is not the same as empty for the mail settings.** An empty `SMTP_HOST` selects the
+   console backend; a wrong one selects SMTP and fails at send time.
+
+The app validates the mail settings at boot and refuses to start on an incoherent combination
+(§5.3). Everything else is trusted and will fail later, in the way described in its row.
+
+---
+
+## 2. Core & security
+
+| Variable | Default | Required |
+|---|---|---|
+| `SECRET_KEY` | random per process | **yes, in production** |
+| `HTTPS` | `false` | no |
+| `FLASK_DEBUG` | `false` | no |
+| `PORT` | `5000` | no |
+| `ENV_FILE` | — | no |
+
+**`SECRET_KEY`** — signs the session cookie. The default is `os.urandom(32).hex()`, generated
+fresh on every process start, which means: with two Gunicorn workers, each worker signs with a
+*different* key, so a logged-in user is randomly logged out depending on which worker answers, and
+every restart logs everyone out. Set it. A leaked key is worse than a rotating one — anyone holding
+it can forge a session cookie for any user, including an admin, without touching a password.
+Generate with `python3 -c "import secrets; print(secrets.token_hex(32))"`.
+
+**`HTTPS`** — set `true` when the app is served over TLS. It turns on `Secure` on the session
+cookie and adds an HSTS header. Left `false` behind real HTTPS, the session cookie is willing to
+travel over plaintext, so a single downgraded request leaks it. Set `true` on a deployment that is
+*not* fully HTTPS and browsers will discard the cookie entirely — you get an app that cannot hold a
+login, which is the confusing failure this variable produces.
+
+**`FLASK_DEBUG`** — `true` enables the Werkzeug debugger. In production that is a remote code
+execution console attached to any traceback. Never `true` on a reachable host. Only read by
+`app.py` (the dev entry point); Gunicorn does not consult it.
+
+**`PORT`** — the port `app.py` binds when run directly. Gunicorn's bind comes from its own command
+line, so changing this does not move the production listener.
+
+**`ENV_FILE`** — path to the `.env` file `app.py` loads via python-dotenv. Unset means dotenv's
+default search. Not used in the Docker images, which pass real environment variables instead.
+
+---
+
+## 3. Storage & database
+
+| Variable | Default | Required |
+|---|---|---|
+| `UPLOAD_FOLDER` | `./uploads` | no (yes in production) |
+| `DATABASE_URL` | `sqlite:///pixelvault.db` | no (yes in production) |
+| `DATA_DIRECTORY` | — | no |
+| `FLASK_TEMPLATES_FOLDER` | `<repo>/templates` | no |
+| `FLASK_STATIC_FOLDER` | `<repo>/static` | no |
+
+**`UPLOAD_FOLDER`** — where uploaded media, thumbnails, and the `partials/` sub-directory of
+in-flight `.part` files live. **This is the user data.** Point it at a path outside the container's
+writable layer and back it up; a relative default inside a container means every uploaded photo
+disappears with `docker compose down`. Changing it on a running deployment does not move existing
+files, so every previously stored photo 404s at `/media/<filename>` while the database still lists
+it.
+
+**`DATABASE_URL`** — SQLAlchemy URI. For an absolute SQLite path you need **four** slashes:
+`sqlite:////data/pixelvault.db`. Three slashes is a *relative* path resolved against the process's
+working directory, which is the classic way to end up with a second, empty database and an app that
+appears to have lost every account. The upload subsystem assumes SQLite semantics (WAL pragmas in
+`extensions.py`); another backend will work but is untested.
+
+**`DATA_DIRECTORY`** — the instance directory the database is placed in. Consumed by the compose
+files and by `scripts/migrate_heic.py` (which derives `DATABASE_URL` from it when that is unset),
+not by `config.py` directly. Setting it without `DATABASE_URL` in an environment that does not do
+that derivation leaves the database at the default relative path.
+
+**`FLASK_TEMPLATES_FOLDER` / `FLASK_STATIC_FOLDER`** — override the template and static roots.
+Only useful when the package is installed somewhere other than the repo checkout; wrong values
+surface as `TemplateNotFound` on the first page render.
+
+---
+
+## 4. Uploads
+
+Full operational treatment, including the per-hop limits these must agree with, is in
+[`upload_operations.md`](upload_operations.md).
+
+| Variable | Default | Required |
+|---|---|---|
+| `MAX_UPLOAD_MB` | `500` | no |
+| `UPLOAD_CHUNK_SIZE` | `8388608` (8 MiB) | no |
+| `UPLOAD_SESSION_TTL_HOURS` | `24` | no |
+| `MAX_CONCURRENT_UPLOADS_PER_USER` | `10` | no |
+| `MAX_INFLIGHT_UPLOAD_MB_PER_USER` | `2048` | no |
+
+**`MAX_UPLOAD_MB`** — becomes `MAX_CONTENT_LENGTH`. It bounds a single request body *and* is
+checked against the declared total size when a chunked upload is initialised — without that second
+check, chunking would leave this bounding only one 8 MiB slice. Set below what users actually
+upload and large files are refused with a 413; set very high and it stops being a meaningful
+defence, since the per-user quotas below become the only thing bounding disk.
+
+**`UPLOAD_CHUNK_SIZE`** — the slice size handed to the client at `init`. It must stay **well under
+the smallest request-body cap in front of the app** — Cloudflare's free plan rejects bodies over
+100 MB at the edge, and the origin never sees the request, so an oversized chunk presents as a
+browser stall with nothing in any server log. Larger chunks mean fewer round trips but more data
+re-sent when one fails; smaller means more database writes, since every accepted chunk commits an
+`UPDATE`.
+
+**`UPLOAD_SESSION_TTL_HOURS`** — how long a partial upload stays resumable before the sweep
+reclaims its row and `.part` file. Too short and a phone that loses signal during a large video
+cannot resume, so the whole transfer restarts. Too long and abandoned partials accumulate on disk
+against the per-user quota, so a user who abandons uploads can lock themselves out of starting new
+ones for the length of the TTL.
+
+**`MAX_CONCURRENT_UPLOADS_PER_USER` / `MAX_INFLIGHT_UPLOAD_MB_PER_USER`** — the load-bearing
+defence against a client filling the disk. They must not be reasoned about as "rate limiting": the
+rate limiter lives in `memory://` per worker and resets on every deploy, so it bounds nothing
+durable. These are DB-backed and do. The byte cap is deliberately tighter than
+`MAX_CONCURRENT_UPLOADS_PER_USER × MAX_UPLOAD_MB` (5 GB at the defaults) — that product is the
+worst case the session count alone would allow, and shrinking it is the entire point. Raise them
+and the worst case per user rises with them.
+
+---
+
+## 5. Mail & invites
+
+Invites are the app's only outbound side effect. Transport lives in
+[`src/pixelvault/mailer.py`](../src/pixelvault/mailer.py) and is deliberately relay-agnostic:
+moving between Gmail, Postmark, SES, or a relay on localhost is an edit to this section and no code
+change.
+
+| Variable | Default | Required |
+|---|---|---|
+| `PUBLIC_BASE_URL` | — | **yes, once SMTP is configured** |
+| `MAIL_ENABLED` | `true` | no |
+| `SMTP_HOST` | — | no |
+| `SMTP_PORT` | `587` | no |
+| `SMTP_USERNAME` | — | no |
+| `SMTP_PASSWORD` | — | no |
+| `SMTP_SECURITY` | `starttls` | no |
+| `MAIL_FROM` | — | **yes, once SMTP is configured** |
+| `MAIL_FROM_NAME` | `PixelVault` | no |
+| `MAIL_TIMEOUT_SECONDS` | `10` | no |
+| `ADMIN_CONTACT` | falls back to `MAIL_FROM` | no |
+| `INVITE_TTL_HOURS` | `72` | no |
+| `INVITE_RESEND_COOLDOWN_SECONDS` | `60` | no |
+
+### 5.1 Which backend you get
+
+`build_mailer()` picks exactly one, in this order:
+
+| Condition | Backend | Behaviour |
+|---|---|---|
+| `MAIL_ENABLED=false` | `NullMailer` | Messages are discarded. Invites are still issued and still usable via the admin copy-link button. |
+| `SMTP_HOST` set | `SMTPMailer` | Real delivery. |
+| otherwise | `ConsoleMailer` | The whole message, link included, is written to the application log. |
+
+`MAIL_ENABLED=false` is checked **first** on purpose: it is an explicit instruction to stop sending,
+so it has to win on a host whose `.env` still carries working credentials.
+
+`ConsoleMailer` is the no-configuration default, which is what lets a dev checkout complete an
+invite flow with no relay — you read the link out of the log and open it. It is also the one place
+in the codebase that logs a message body; everywhere else that is forbidden, because the invite
+token in the body is a bearer credential that creates an account.
+
+### 5.2 The variables
+
+**`PUBLIC_BASE_URL`** — the canonical external origin invite links are built from, e.g.
+`https://photos.example.com`. Deliberately *not* derived from the request (`url_for(_external=True)`):
+behind Cloudflare → nginx → Gunicorn the reconstructed URL is only as trustworthy as the forwarded
+headers, so an attacker-controlled `Host` header on the add-email request could otherwise mint an
+invite pointing at a domain they control — and the recipient would have no way to tell. Set it to
+the origin users actually type. A trailing slash is stripped automatically. Point it at the wrong
+host and every invite email is undeliverable in practice: the link resolves somewhere else.
+
+**`MAIL_ENABLED`** — `false` turns off delivery without turning off invites. The right setting for
+an operator who does not want to run a relay and is happy to hand links over by other means.
+
+**`SMTP_HOST`** — the relay. Empty means no relay, which is a supported configuration, not an
+error. Wrong or unreachable and every invite send fails; the invite itself still exists (the row is
+committed before the send is attempted) and the admin panel shows the failure with a **Resend**
+button.
+
+**`SMTP_PORT`** — 587 for STARTTLS, 465 for implicit TLS, 25 for an unauthenticated local relay.
+A port that disagrees with `SMTP_SECURITY` is the most common mail misconfiguration: 465 with
+`starttls` hangs until `MAIL_TIMEOUT_SECONDS` (the server is waiting for a TLS handshake while the
+client sends plaintext), and 587 with `ssl` fails the handshake immediately.
+
+**`SMTP_USERNAME` / `SMTP_PASSWORD`** — blank username means no `AUTH` command at all, for a relay
+that authenticates by network location. The password is the one value here that is **not** stripped
+of surrounding whitespace, because Gmail app passwords are usually pasted with their grouping
+spaces and a password may legitimately end in one.
+
+**`SMTP_SECURITY`** — `starttls` | `ssl` | `none`. With `starttls` the connection is upgraded
+*before* `AUTH`, so credentials never cross a plaintext socket. `none` sends everything, including
+the password, in the clear — only defensible for a relay on `localhost`. An unrecognised value is a
+boot failure, not a send-time one.
+
+**`MAIL_FROM`** — envelope and header sender. Empty with SMTP configured is a boot failure, because
+every relay rejects a message with no sender and the failure would otherwise appear only when the
+first invite is sent. See the Gmail profile below for why this is not free to choose.
+
+**`MAIL_FROM_NAME`** — display name beside the address. Cosmetic.
+
+**`MAIL_TIMEOUT_SECONDS`** — socket timeout for the entire SMTP conversation, connect included.
+Sends happen synchronously inside the admin's request and production runs 2 workers × 4 threads, so
+this is what stands between a relay that accepts a TCP connection and then goes quiet and one of
+only eight threads being held for the OS default — minutes, not seconds. Raise it and you trade
+thread availability for patience with a slow relay; lower it much below 10 and legitimately slow
+handshakes start failing.
+
+**`ADMIN_CONTACT`** — the address shown to share-link visitors who have no account, so they know
+who to ask for an invitation. Registration is link-only, so without a usable value here that page
+is a dead end. Defaults to `MAIL_FROM`.
+
+**`INVITE_TTL_HOURS`** — link lifetime, measured from issue or resend. Long values are friendlier
+to someone who checks mail weekly, and are also a longer window in which a link sitting in a
+forwarded message, a shared mailbox, or a mail archive is still usable by whoever finds it.
+
+**`INVITE_RESEND_COOLDOWN_SECONDS`** — minimum gap between two sends of one invite. Not an
+anti-annoyance measure: an invite is mail *this server sends to a third party on request*, so a
+resend button with no cooldown is a mail-bomb primitive pointed at whatever address was typed in,
+and the sending domain's standing with the relay is what pays for it. Setting it to `0` removes
+that protection.
+
+### 5.3 Boot-time validation
+
+`create_app()` refuses to start on a mail configuration that would only fail later, when an admin
+has already promised someone an email:
+
+| Combination | Result |
+|---|---|
+| `SMTP_HOST` set, `MAIL_FROM` empty | `RuntimeError` at boot |
+| `SMTP_HOST` set, `PUBLIC_BASE_URL` empty | `RuntimeError` at boot |
+| `SMTP_HOST` set, `SMTP_SECURITY` not one of the three modes | `RuntimeError` at boot |
+| No `SMTP_HOST` at all | **Boots normally** on `ConsoleMailer` |
+| `MAIL_ENABLED=false`, anything else | **Boots normally** on `NullMailer` |
+
+The last two rows are the point: a dev checkout with no mail configuration must still start. The
+checks fire only once someone has begun configuring a relay and stopped halfway.
+
+### 5.4 Gmail profile
+
+Gmail is the first relay this app was deployed against. Nothing in the code knows that — these are
+settings, and switching relays is a `.env` edit.
+
+```ini
+SMTP_HOST=smtp.gmail.com
+SMTP_PORT=587
+SMTP_SECURITY=starttls
+SMTP_USERNAME=you@gmail.com
+SMTP_PASSWORD=<16-character app password>
+MAIL_FROM=you@gmail.com
+```
+
+Four things to know before you use it:
+
+1. **`SMTP_PASSWORD` must be an app password, not the account password.** Google rejects the
+   account password over SMTP outright. Generating one **requires 2-Step Verification to be enabled
+   on the account first** — the app-password page does not exist otherwise, which is why this looks
+   like a missing feature rather than a prerequisite.
+2. **`MAIL_FROM` must be the `SMTP_USERNAME` account.** Google rewrites a `From` header it does not
+   own, so a different address does not fail loudly — it is silently replaced, and your carefully
+   chosen sender never reaches anyone.
+3. **Roughly 500 messages per day** on a consumer account. Ample for invites; the ceiling to
+   remember if this mailer is later reused for notifications.
+4. **Deliverability is the real limitation.** Mail from a `@gmail.com` sender for a domain with no
+   matching SPF/DKIM records lands in spam noticeably more often than mail from a domain that
+   authenticates its own sending. The copy-link fallback in the admin panel exists partly for this.
+   If invites routinely go missing, that is the signal to move to a transactional provider
+   (Postmark, SES, Resend) on your own domain — which is a change to this section, not to any code.
+
+---
+
+## 6. Reverse proxy
+
+| Variable | Default | Required |
+|---|---|---|
+| `TRUSTED_PROXY_COUNT` | `1` | no |
+
+**`TRUSTED_PROXY_COUNT`** — the number of proxies that append to `X-Forwarded-For` before a request
+reaches the app, handed to `ProxyFix`. Cloudflare → nginx → app is **2**, *if* your nginx uses
+`proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for`.
+
+Setting it **higher than the true hop count is a security hole, not a tuning mistake**: the
+client's own `X-Forwarded-For` header then survives into the region `ProxyFix` trusts, so a caller
+can name any address it likes and choose which rate-limit bucket it is charged under — which is to
+say, it can have a fresh bucket per request. **When unsure, set it too low.** The cost of too low
+is that everyone behind the proxy shares one bucket; the cost of too high is that the limiter can
+be bypassed entirely.
+
+Rate limits on authenticated routes key on user id rather than address (see `rate_limit_key` in
+`extensions.py`), so this matters most for the pre-auth routes: login, and the invite links.
+
+---
+
+## 7. Admin bootstrap
+
+| Variable | Default | Required |
+|---|---|---|
+| `ADMIN_USERNAME` | — | no |
+| `ADMIN_EMAIL` | — | no |
+| `ADMIN_PASSWORD` | — | no |
+
+Used by `flask --app app create-admin` and by `scripts/create_admin.py`. **`create_app()` also
+seeds an admin at startup whenever `ADMIN_EMAIL` is non-empty**, which is what the test container
+relies on — and is worth knowing before you leave these set on a long-lived deployment, since the
+password sits in the environment of every process for as long as they are there. Set them for the
+first boot, then remove them.
+
+Registration is invite-only, so these are the only way to create the first account.
+
+---
+
+## 8. Quick reference
+
+| Variable | Default | Section |
+|---|---|---|
+| `SECRET_KEY` | random per process | [Core](#2-core--security) |
+| `HTTPS` | `false` | [Core](#2-core--security) |
+| `FLASK_DEBUG` | `false` | [Core](#2-core--security) |
+| `PORT` | `5000` | [Core](#2-core--security) |
+| `ENV_FILE` | — | [Core](#2-core--security) |
+| `UPLOAD_FOLDER` | `./uploads` | [Storage](#3-storage--database) |
+| `DATABASE_URL` | `sqlite:///pixelvault.db` | [Storage](#3-storage--database) |
+| `DATA_DIRECTORY` | — | [Storage](#3-storage--database) |
+| `FLASK_TEMPLATES_FOLDER` | `<repo>/templates` | [Storage](#3-storage--database) |
+| `FLASK_STATIC_FOLDER` | `<repo>/static` | [Storage](#3-storage--database) |
+| `MAX_UPLOAD_MB` | `500` | [Uploads](#4-uploads) |
+| `UPLOAD_CHUNK_SIZE` | `8388608` | [Uploads](#4-uploads) |
+| `UPLOAD_SESSION_TTL_HOURS` | `24` | [Uploads](#4-uploads) |
+| `MAX_CONCURRENT_UPLOADS_PER_USER` | `10` | [Uploads](#4-uploads) |
+| `MAX_INFLIGHT_UPLOAD_MB_PER_USER` | `2048` | [Uploads](#4-uploads) |
+| `PUBLIC_BASE_URL` | — | [Mail](#5-mail--invites) |
+| `MAIL_ENABLED` | `true` | [Mail](#5-mail--invites) |
+| `SMTP_HOST` | — | [Mail](#5-mail--invites) |
+| `SMTP_PORT` | `587` | [Mail](#5-mail--invites) |
+| `SMTP_USERNAME` | — | [Mail](#5-mail--invites) |
+| `SMTP_PASSWORD` | — | [Mail](#5-mail--invites) |
+| `SMTP_SECURITY` | `starttls` | [Mail](#5-mail--invites) |
+| `MAIL_FROM` | — | [Mail](#5-mail--invites) |
+| `MAIL_FROM_NAME` | `PixelVault` | [Mail](#5-mail--invites) |
+| `MAIL_TIMEOUT_SECONDS` | `10` | [Mail](#5-mail--invites) |
+| `ADMIN_CONTACT` | `MAIL_FROM` | [Mail](#5-mail--invites) |
+| `INVITE_TTL_HOURS` | `72` | [Mail](#5-mail--invites) |
+| `INVITE_RESEND_COOLDOWN_SECONDS` | `60` | [Mail](#5-mail--invites) |
+| `TRUSTED_PROXY_COUNT` | `1` | [Proxy](#6-reverse-proxy) |
+| `ADMIN_USERNAME` | — | [Admin](#7-admin-bootstrap) |
+| `ADMIN_EMAIL` | — | [Admin](#7-admin-bootstrap) |
+| `ADMIN_PASSWORD` | — | [Admin](#7-admin-bootstrap) |

--- a/docs/database_schema.md
+++ b/docs/database_schema.md
@@ -16,6 +16,16 @@ erDiagram
         string email "unique, max 120"
         string note "max 256"
         datetime added_at
+        string token_hash "sha256 hex, max 64, nullable, indexed"
+        datetime token_issued_at "nullable"
+        datetime expires_at "nullable"
+        string prefill_username "max 64, default empty"
+        datetime last_sent_at "nullable"
+        int send_count "default 0"
+        string last_send_error "max 256, default empty"
+        datetime accepted_at "nullable"
+        int accepted_user_id FK "nullable"
+        int invited_by_id FK "nullable"
     }
 
     Album {
@@ -52,8 +62,64 @@ erDiagram
     }
 
     User ||--o{ Album : "owns"
+    User ||--o{ AllowedEmail : "invited"
+    User ||--o| AllowedEmail : "accepted as"
     User ||--o{ AlbumAccess : "has access"
     User ||--o{ Photo : "uploads"
     Album ||--o{ Photo : "contains"
     Album ||--o{ AlbumAccess : "grants"
 ```
+
+---
+
+## AllowedEmail — the invite lifecycle
+
+`AllowedEmail` is not a passive whitelist. One row is both the assertion that an
+address may register *and* the credential that carries that permission to a person,
+so it has a lifecycle. See [invite_registration_design.md](invite_registration_design.md)
+§4 for why this is one table and not two.
+
+**The token is never stored.** `token_hash` holds the SHA-256 of a
+`secrets.token_urlsafe(32)` value; the plaintext exists only in the sent email and,
+for the copy-link fallback, in one flash message. A leaked backup or a screenshot of
+the admin page therefore cannot be used to create an account — and, as the accepted
+cost, a link can never be re-shown, so resending mints a new token and kills the old
+one. Lookup is an indexed equality match on the hash.
+
+`expires_at` is denormalised from `token_issued_at` + `INVITE_TTL_HOURS` so the admin
+table can display and sort honest expiry without re-deriving it against a config value
+that may have changed since the token was minted.
+
+### States
+
+`AllowedEmail.state` is a **derived property**, never a column: the expiry test reads
+the wall clock, so a stored value would be wrong from the moment a TTL lapsed with
+nobody looking. It is evaluated in this order, and the order is the specification —
+several rows satisfy more than one test at once.
+
+| # | State | Row looks like | What an admin does about it |
+|---|---|---|---|
+| 1 | `ACCEPTED` | `accepted_at` set (`token_hash` nulled by consumption) | Nothing. Terminal — it outranks a TTL that lapsed afterwards. |
+| 2 | `LEGACY` | no `token_hash`, never accepted | **Send invite.** Pre-migration rows land here. |
+| 3 | `EXPIRED` | `now >= expires_at` | **Resend** — which rotates the token. |
+| 4 | `SEND_FAILED` | `last_send_error` non-empty, token still live | Resend, or hand over the copy-link. The credential is fine; only delivery failed, which is why it ranks below `EXPIRED`. |
+| 5 | `ISSUED` | token live, `last_sent_at` is NULL | Nothing sent yet — the copy-link path, or mail disabled. |
+| 6 | `SENT` | token live, delivered, unclicked | Wait, then resend past the cooldown. |
+
+`is_pending` is true for exactly `ISSUED`, `SENT`, and `SEND_FAILED` — the states where
+a working link is outstanding.
+
+`LEGACY` is load-bearing, not cosmetic. Every `allowed_email` row created before this
+feature has no token, and once registration is link-only those addresses can no longer
+be used at all. The state is what lets the admin panel list them as *"No invite sent"*
+with a **Send invite** button, rather than having a migration email a year-old address
+on deploy day.
+
+### Migration
+
+All ten columns are added by `_run_migrations()` as individual
+`ALTER TABLE allowed_email ADD COLUMN` statements, plus
+`CREATE INDEX IF NOT EXISTS ix_allowed_email_token_hash`. The three non-nullable columns
+carry a literal SQL `DEFAULT` (`''`, `0`, `''`) because SQLite rejects a non-constant
+default on `ADD COLUMN` and existing rows must be writable; the nullable ones take no
+default, which is exactly what makes an untouched row read as `LEGACY`.

--- a/docs/invite_registration_design.md
+++ b/docs/invite_registration_design.md
@@ -1,0 +1,548 @@
+# Invite-Based Registration — Architectural Design
+
+Design plan for [#7](https://github.com/gfvandehei/PixelVault/issues/7).
+
+**Status:** accepted. Every open question in §11 is now decided. §13 is the **API contract**:
+modules are built in sequence by separate contributors, so no one may change a signature there
+without editing this file first — the same rule `docs/upload_protocol.md` runs under.
+
+---
+
+## 1. What changes, and why
+
+Registration today is a two-step ritual split across two people who are not in the same room:
+an admin types an email into `/admin`, then tells the invitee out-of-band to go to `/register`
+and type that *same* email, a username, and a password. Nothing connects the two halves — the
+whitelist row is a passive assertion checked at the end of the form, and every mismatch
+(typo, alias, `+tag`, different capitalisation) surfaces as the same dead-end message,
+*"This email address has not been authorized to register."*
+
+The target flow, from the issue's comments:
+
+1. Admin adds an email. **An invite email sends automatically**, carrying a link.
+2. Invitee clicks the link. It opens the registration form with the **email already filled in
+   and not editable**; they choose a username and password and submit.
+3. The link is **consumed** — single-use, and expiring on its own if never clicked.
+4. **Registration is reachable only through such a link.** The "Sign up" link on the login
+   page goes away.
+5. The admin panel shows **per-invite state** and offers **resend**.
+
+The architectural consequence is larger than the feature: `AllowedEmail` stops being a passive
+whitelist and becomes a **credential with a lifecycle** (issued → sent → accepted / expired /
+revoked), and the app acquires its **first outbound side effect** — SMTP. Both deserve their
+own modules rather than more code inside route handlers.
+
+---
+
+## 2. Design principles applied
+
+The repo already demonstrates the pattern this should follow: `uploads.py` holds the upload
+session lifecycle as plain functions over the ORM, and `routes/share.py` is a thin HTTP layer
+over it. Invites get the same treatment.
+
+- **Domain logic out of routes.** `invites.py` never imports `flask.request` and never
+  renders. It can be tested without an HTTP client, the way `uploads.py` can.
+- **Transport does not know about invites.** `mailer.py` sends a message. It has no idea what
+  an invite is, which makes it reusable for the next email the app needs (password reset,
+  upload notifications, issue #11 comment notifications) without a rewrite.
+- **Content is not transport.** Rendering "here is your invite" into a subject + text + HTML
+  body is a third concern, in `emails.py`. Swapping SMTP for a provider API touches one file;
+  rewording the invite touches a different one.
+- **Config is env-driven and validated at boot**, consistent with `config.py`.
+- **Migrations are additive `ALTER TABLE`**, consistent with `_run_migrations()`.
+
+---
+
+## 3. Module layout
+
+```
+src/pixelvault/
+├── config.py            # (+) SMTP settings, PUBLIC_BASE_URL, invite TTL & cooldown
+├── extensions.py        # (+) `mailer` singleton with init_app(app), beside db/login_manager/limiter
+├── models.py            # (+) invite columns on AllowedEmail (see §4)
+├── mailer.py            # NEW — transport only: build a Mailer from config, send a message
+├── emails.py            # NEW — renders app messages (invite) from Jinja templates
+├── invites.py           # NEW — invite lifecycle: issue, rotate, validate, consume, sweep
+└── routes/
+    ├── admin.py         # (~) add now issues+sends; new resend / revoke / copy-link actions
+    └── auth.py          # (~) /register removed; /invite/<token> GET+POST added
+templates/
+├── email/
+│   ├── invite.txt       # NEW — plain-text part (the part that always renders)
+│   └── invite.html      # NEW — HTML part
+├── register.html        # (~) becomes the invite acceptance form: email locked, token carried
+├── login.html           # (~) "Sign up" link removed
+└── admin.html           # (~) invite state column + resend / copy-link buttons
+docs/
+└── registration_invites.md   # NEW — operator doc (SMTP setup, troubleshooting, states)
+tests/
+├── test_invite_lifecycle.py  # NEW
+├── test_invite_access.py     # NEW
+└── test_mailer.py            # NEW
+```
+
+### Dependency direction
+
+```
+routes/admin.py ─┐
+routes/auth.py ──┼──▶ invites.py ──▶ models.py
+                 └──▶ emails.py ──▶ mailer.py ──▶ smtplib
+                                └──▶ Jinja (templates/email/)
+```
+
+Nothing points back up. `invites.py` does not send email; the route asks `invites` for a token
+and then asks `emails` to deliver it, so an invite can be issued without SMTP configured at all
+(the copy-link fallback, §7.3).
+
+---
+
+## 4. Data model
+
+**Recommendation: extend `AllowedEmail` rather than add an `Invitation` table.** An authorized
+email and an outstanding invite are the same fact in this app — there is no case where one
+exists without the other, so two tables would mean two rows to keep in sync and a join on every
+admin page render. Keeping the table name `allowed_email` also means the migration is pure
+`ADD COLUMN`, which is what `_run_migrations()` does well. (See §11 Q1 — a separate table wins
+if you ever want invite *history* per address.)
+
+New columns:
+
+| Column | Type | Purpose |
+|---|---|---|
+| `token_hash` | `String(64)`, nullable, indexed | SHA-256 of the invite token. Null once accepted or for legacy rows. |
+| `token_issued_at` | `DateTime`, nullable | When the current token was minted; expiry measured from here. |
+| `expires_at` | `DateTime`, nullable | Denormalised for cheap querying and honest display in the admin table. |
+| `prefill_username` | `String(64)`, default `''` | Optional admin-suggested username (issue comment 1). |
+| `last_sent_at` | `DateTime`, nullable | Drives the resend cooldown and the "Sent 3 days ago" label. |
+| `send_count` | `Integer`, default `0` | How many times an email went out; surfaces "resent 4×, still not accepted". |
+| `last_send_error` | `String(256)`, default `''` | Truncated SMTP failure, shown to the admin. Empty on success. |
+| `accepted_at` | `DateTime`, nullable | Set when the account is created. Non-null = terminal state. |
+| `accepted_user_id` | `Integer`, FK `user.id`, nullable | Links the invite to the account it produced. |
+| `invited_by_id` | `Integer`, FK `user.id`, nullable | Audit: which admin issued it. |
+
+Derived state — a property on the model, not a stored column, so it cannot go stale:
+
+```
+accepted_at is not None            → ACCEPTED
+token_hash is None                 → LEGACY      (pre-migration row; needs an invite issued)
+now >= expires_at                  → EXPIRED
+last_send_error                    → SEND_FAILED (token is valid; delivery is what failed)
+last_sent_at is None               → ISSUED      (token exists, never emailed — copy-link path)
+otherwise                          → SENT
+```
+
+`LEGACY` is not a cosmetic state. Existing production rows have no token, and once `/register`
+is link-only they would be silently unusable. The admin panel must show them as
+*"No invite sent"* with a **Send invite** button, and the release notes must say so.
+
+### Token handling
+
+- Generated with `secrets.token_urlsafe(32)` (256 bits) — brute force is not a threat model.
+- **Only the SHA-256 hash is stored.** The plaintext exists in the email and, for the copy-link
+  fallback, in one flash message. This matters because the token is a bearer credential that
+  creates an account bound to a real person's email; a leaked DB backup or an admin-page
+  screenshot should not be enough to use it. Plain SHA-256 (not bcrypt) is correct here: the
+  secret is 256 random bits, so there is no dictionary to slow down.
+- Lookup is `WHERE token_hash = sha256(presented)`, an indexed equality match — no scan, and no
+  timing signal worth defending against beyond `hmac.compare_digest` on the final compare.
+- **Resend rotates the token.** The consequence of hashing is that a link cannot be re-shown, so
+  "resend" mints a new one and the old link stops working. That is the safer default anyway: a
+  resend usually means the first link went somewhere it shouldn't have or is presumed lost.
+  (§11 Q2 if you would rather the link stay stable.)
+- Consumption is a single transaction: create `User`, set `accepted_at` / `accepted_user_id`,
+  null out `token_hash`, commit. A double-submit or a shared link therefore loses the race
+  cleanly on the unique constraint rather than creating two accounts.
+
+---
+
+## 5. `mailer.py` — transport
+
+One small surface, several backends:
+
+```python
+class Mailer:
+    def send(self, message: EmailMessage) -> None: ...   # raises MailError
+
+class SMTPMailer(Mailer):  ...   # STARTTLS or implicit TLS, timeout-bounded
+class ConsoleMailer(Mailer): ... # prints to the log — dev default, no config needed
+class NullMailer(Mailer):  ...   # discards; MAIL_ENABLED=false
+class MemoryMailer(Mailer): ...  # keeps a list; the test fixture
+```
+
+- `build_mailer(config)` picks one from env: SMTP host set → `SMTPMailer`; `MAIL_ENABLED=false`
+  → `NullMailer`; otherwise `ConsoleMailer`. A dev checkout with no SMTP config keeps working,
+  and the invite link is in the console where a developer can click it.
+- **Gmail is the first relay, and nothing above `build_mailer` may learn that.** `SMTPMailer`
+  stays generic — host, port, security mode, credentials, all from config — and Gmail's
+  specifics (app password, `MAIL_FROM` forced to the account address because Google rewrites
+  anything else, the 500/day cap) live in `docs/registration_invites.md` as one profile among
+  several. Switching to Postmark or SES later is then an `.env` edit, and switching to a
+  provider's **HTTP API** is a new `Mailer` subclass plus one line in `build_mailer` — no caller
+  changes, because `emails.py` only ever sees `Mailer.send`. That seam is the entire reason
+  transport is its own module.
+- Registered as `mailer` in `extensions.py` with `init_app(app)`, matching `db` / `limiter`, so
+  routes get to it the same way they get to everything else, and tests swap it in one place.
+- Every send is bounded by `MAIL_TIMEOUT_SECONDS` (default 10) on the socket. Without it a
+  hung SMTP server pins a Gunicorn thread — there are only 8.
+- Failures raise `MailError`; the caller decides. `mailer.py` never flashes, never aborts, and
+  **never logs the message body** (the invite token is in it).
+
+### When the send happens
+
+**Recommendation: synchronously, inside the admin request.** Invites are rare, admin-triggered,
+and one-at-a-time; a 10-second worst case on a button an admin presses a handful of times a
+month is a fair trade for the admin learning *immediately* whether delivery worked. The
+alternative — a thread or an outbox table — buys throughput this app has no use for and costs a
+polling UI, and 2×4 threads means a background sender competes with uploads for the same pool.
+The recorded `last_send_error` plus a **Resend** button covers the failure case without a queue.
+(§11 Q3.)
+
+---
+
+## 6. `emails.py` — content
+
+```python
+def build_invite_email(invite, token, base_url) -> EmailMessage
+def send_invite(mailer, invite, token, base_url) -> None    # build + send + stamp the row
+```
+
+- Bodies render from `templates/email/invite.{txt,html}` via the app's Jinja env, so the copy
+  lives with the other templates and is reviewable as text, not as a Python string.
+- **`multipart/alternative`, and the text part is authored first.** The HTML part is the
+  garnish; if it is ever malformed, the invite link still arrives intact.
+- The link is built from **`PUBLIC_BASE_URL`**, not `url_for(_external=True)`. Behind
+  Cloudflare → nginx → Gunicorn, the URL the app reconstructs is only as trustworthy as the
+  forwarded headers, and an attacker-controlled `Host` header on the *add-email* request would
+  otherwise steer an invite link at a domain they own. An explicit configured origin removes
+  the question. Boot fails loudly if SMTP is enabled and `PUBLIC_BASE_URL` is unset.
+- Nothing token-shaped is ever passed to a logger.
+
+---
+
+## 7. Request flows
+
+### 7.1 Issuing (admin adds an email)
+
+```
+POST /admin/email/add   (admin, 60/hour)
+  ├─ normalise + validate email (reuse RE_EMAIL — currently this route only checks for '@')
+  ├─ already a User with that email?      → flash "already registered", stop
+  ├─ already an AllowedEmail?             → flash "already invited", offer resend, stop
+  ├─ invites.issue(email, note, prefill_username, invited_by=current_user)
+  │     → row committed, plaintext token returned once
+  ├─ emails.send_invite(...)              → on MailError: record last_send_error, flash the
+  │                                          failure with a "copy link" fallback (§7.3)
+  └─ redirect to /admin
+```
+
+The row is committed **before** the send is attempted. If SMTP is down the invite still exists
+and is resendable; the alternative (rollback on send failure) throws away a valid invite because
+of an unrelated outage.
+
+### 7.2 Accepting
+
+```
+GET  /invite/<token>   (anonymous, 60/hour per IP)
+  ├─ invites.validate(token) → invite | InvalidInvite | ExpiredInvite
+  ├─ already logged in?  → log out or refuse; an invite must not attach to a live session
+  ├─ stash the token in the session, redirect to GET /invite  (see §11 Q5)
+  └─ render register.html: email shown read-only, username prefilled, token in a hidden field
+
+POST /invite           (anonymous, 20/hour per IP)
+  ├─ re-validate the token from the session — the GET's verdict is not carried over
+  ├─ validate username / password exactly as today
+  ├─ **email comes from the invite row, never from the form**
+  ├─ single transaction: create User, mark invite accepted, null token_hash
+  └─ login_user(), redirect to dashboard
+```
+
+The email is taken from the server-side row, not the posted field. Anything else lets a holder
+of an invite for `alice@` register as `bob@` and defeats the whole point of the whitelist —
+this is the single most important line in the feature.
+
+### 7.3 Copy-link fallback
+
+When SMTP fails, or is not configured at all (a self-hoster who does not want a mail relay),
+the admin needs a way to hand over the link. `POST /admin/invite/<id>/link` **rotates** the
+token and flashes the fresh URL once, with a "copy" button. This makes SMTP genuinely optional
+rather than a hard dependency of the whole registration system, and it is the thing to reach
+for when an invite lands in someone's spam folder.
+
+### 7.4 Resend
+
+`POST /admin/invite/<id>/resend` — rotates the token, re-sends, bumps `send_count`, stamps
+`last_sent_at`. Rejected if `last_sent_at` is within `INVITE_RESEND_COOLDOWN_SECONDS`
+(default 60). The cooldown is not primarily about the admin: an invite email is mail *this
+server sends to a third party on request*, and an unthrottled resend button is a mail-bomb
+primitive pointed at whatever address is typed in. It also protects the sending domain's
+reputation with the relay.
+
+### 7.5 Revoking
+
+The existing `POST /admin/email/<id>/remove` keeps working and now also kills the token, since
+the token lives on the row being deleted. For accepted invites, deletion should **not** cascade
+to the user account — worth a confirm-dialog wording change ("this removes the invite record;
+the account stays").
+
+---
+
+## 8. Removing public registration
+
+- `/register` is deleted as a route. Requests to it → 404 (not a redirect to `/login`, which
+  would imply the page moved). `templates/register.html` is repurposed as the invite acceptance
+  form rather than deleted, since 90% of it is unchanged.
+- `login.html` loses its "Don't have an account? Sign up" footer. Replacing it with a plain
+  *"PixelVault is invite-only. Ask an admin for an invitation."* is honest and stops the
+  support question before it is asked.
+- **Known collateral — decided (§11 Q6):** every album route is `@login_required`, so a guest
+  who receives a share link and has no account currently self-registers to view it. After this
+  change that path closes, so `request_permission.html` must stop being a dead end: it gains
+  copy naming the admin to contact for an invitation, sourced from a config value
+  (`ADMIN_CONTACT`, defaulting to `MAIL_FROM`) rather than hard-coded. No public
+  "request an invite" endpoint — that would be a new unauthenticated write surface to throttle
+  and moderate, for a flow that happens a handful of times a year.
+- The `AllowedEmail` check stays in the acceptance path as a belt-and-braces assertion even
+  though a valid token already implies it — the row *is* the whitelist entry.
+
+---
+
+## 9. Configuration
+
+| Variable | Default | Description |
+|---|---|---|
+| `PUBLIC_BASE_URL` | — | Canonical external origin, e.g. `https://photos.example.com`. **Required when mail is enabled.** |
+| `MAIL_ENABLED` | `true` | `false` → `NullMailer`; invites are issued but nothing is sent. |
+| `SMTP_HOST` | — | Unset → `ConsoleMailer` (link printed to the log). |
+| `SMTP_PORT` | `587` | 465 implies implicit TLS, 587 STARTTLS. |
+| `SMTP_USERNAME` / `SMTP_PASSWORD` | — | Blank = unauthenticated relay. |
+| `SMTP_SECURITY` | `starttls` | `starttls` \| `ssl` \| `none`. |
+| `MAIL_FROM` | — | Envelope + header From. |
+| `MAIL_FROM_NAME` | `PixelVault` | Display name. |
+| `MAIL_TIMEOUT_SECONDS` | `10` | Socket timeout; bounds how long one Gunicorn thread is held. |
+| `ADMIN_CONTACT` | falls back to `MAIL_FROM` | Address shown to accountless guests on `request_permission.html`. |
+| `INVITE_TTL_HOURS` | `72` | Link lifetime from issue/rotate. |
+| `INVITE_RESEND_COOLDOWN_SECONDS` | `60` | Minimum gap between sends for one invite. |
+
+Validated at import in `config.py`; `create_app()` fails fast on the incoherent combinations
+(mail enabled with no `MAIL_FROM`, SMTP configured with no `PUBLIC_BASE_URL`). `.env.example`,
+`.env.prod`, both compose files and `docker/Dockerfile.prod`'s env passthrough all need the new
+keys — the compose files enumerate variables explicitly, so anything not added there is silently
+absent in production.
+
+**No new Python dependency.** `smtplib` and `email.message` are stdlib; Flask-Mail would add a
+dependency to wrap them and would still not give us the state machine, which is the actual work.
+A future HTTP-API backend would add `requests`/`httpx` — one more reason to keep that behind the
+`Mailer` interface rather than in the routes.
+
+**Gmail profile** (the initial deployment): `SMTP_HOST=smtp.gmail.com`, `SMTP_PORT=587`,
+`SMTP_SECURITY=starttls`, `SMTP_USERNAME` = the account, `SMTP_PASSWORD` = a 16-character
+**app password** (not the account password — it requires 2FA to be enabled on the account), and
+`MAIL_FROM` = that same account, since Google rewrites a `From` it does not own. Worth stating
+in the operator doc: invites from a `@gmail.com` sender land in spam more often than from a
+domain with SPF/DKIM, which is the argument for moving to a transactional provider later.
+
+---
+
+## 10. Rate limits, security, and testing
+
+### Rate limits (new rows for the CLAUDE.md table)
+
+| Endpoint | Limit | Key |
+|---|---|---|
+| `GET /invite/<token>` | 60/hour | IP (pre-auth) |
+| `POST /invite` | 20/hour | IP |
+| `POST /admin/invite/<id>/resend` | 30/hour | user |
+| `POST /admin/invite/<id>/link` | 30/hour | user |
+
+Per `extensions.rate_limit_key`, admin actions key on user id and the anonymous invite routes
+fall back to IP — the same split `/login` and `/register` already use.
+
+### Security checklist
+
+- Email is server-side, never from the form (§7.2). The highest-value line in the change.
+- Token hashed at rest; plaintext only in the email and one flash.
+- Single-use, enforced in the same transaction as user creation.
+- TTL-bounded; expiry measured from issue/rotate.
+- Invite link never logged; `last_send_error` is truncated and carries no token.
+- `PUBLIC_BASE_URL` removes `Host`-header influence over where the link points.
+- Resend cooldown so the app is not a mail-bomb relay.
+- Accepting while already logged in is refused, not silently merged.
+- `Referrer-Policy: strict-origin-when-cross-origin` is already set, so a token in the URL does
+  not leak cross-origin — but it *does* land in nginx access logs and browser history, which is
+  what §11 Q5's session-stash redirect is about.
+
+### Tests
+
+Following `conftest.py`'s existing discipline (env stamped before `pixelvault` is imported, so
+invite TTL and cooldown must be chosen there, not in a test):
+
+| Module | Covers |
+|---|---|
+| `test_mailer.py` | Backend selection from config; timeout applied; `MailError` on refusal; `MemoryMailer` captures subject/recipients/both parts. |
+| `test_invite_lifecycle.py` | Issue → send → accept; token single-use; rotation on resend invalidates the old link; TTL expiry; cooldown; state property across all six states incl. `LEGACY`. |
+| `test_invite_access.py` | **Email cannot be overridden via the form**; invalid/garbage token; accepting twice; accepting while logged in; `/register` is gone; admin routes reject non-admins; rate limits. |
+
+A `mailer` fixture swapping `MemoryMailer` into `extensions` gives every test a real assertion
+on what would have been sent, with no network.
+
+---
+
+## 11. Decisions and open questions
+
+### Settled
+
+**Q2 — Token at rest: hashed.** Only the SHA-256 lands in the DB, so a leaked backup or an admin
+screenshot cannot be used to register. The accepted cost: a link is unrecoverable, so **resend
+and copy-link both rotate the token** and the previous link dies immediately.
+
+**Q4 — Relay: Gmail now, swappable later.** `SMTPMailer` stays relay-agnostic; Gmail's app
+password, forced `MAIL_FROM`, and daily cap are documented as one profile in the operator doc
+(§9). Moving to Postmark/SES is an `.env` edit; moving to a provider's HTTP API is one new
+`Mailer` subclass. Nothing above `build_mailer` may reference Gmail.
+
+**Q6 — Accountless share-link guests: name the admin.** `request_permission.html` tells them who
+to ask, using `ADMIN_CONTACT`. No public invite-request endpoint.
+
+**Q9 — Legacy `allowed_email` rows: manual.** They render as `LEGACY` / "No invite sent" with a
+**Send invite** button. Nothing is emailed without an admin click, so a forgotten address from a
+year ago does not get a surprise invite on deploy day.
+
+### Also settled (recommended defaults, accepted)
+
+**Q1 — One table.** `AllowedEmail` is extended; no separate `Invitation` table. One row per
+address, migration is pure `ADD COLUMN`, no join on the admin page. The cost accepted: an
+address keeps only its *current* invite state, not a history of every rotation.
+
+**Q3 — Synchronous send.** Inside the admin request, bounded by `MAIL_TIMEOUT_SECONDS`. The
+admin learns immediately whether delivery worked. No thread, no outbox table, no polling UI.
+
+**Q5 — Stash the token in the session, redirect to a clean URL.** `GET /invite/<token>`
+validates, puts the token in `session['invite_token']`, and redirects to `GET /invite`, which
+carries no secret. Keeps the token out of nginx access logs and browser history — the other half
+of the protection hashing at rest gives us.
+
+**Q7 — 72-hour TTL, expiring to a dead row.** An expired invite stays visible in the admin panel
+as `EXPIRED` and needs an explicit **Resend**. No auto-reissue: that would silently re-email
+someone, which is exactly what the Q9 decision rules out.
+
+**Q8 — Prefill is a suggested username plus the admin-only note.** The invitee may change the
+username. **No `is_admin` flag on invites** — admin accounts stay a deliberate, separate act, so
+a mistyped checkbox on an invite form can never mint an administrator.
+
+---
+
+## 13. API contract
+
+Signatures are fixed here so modules built in sequence fit together without rework.
+
+### `mailer.py` — transport
+
+```python
+class MailError(RuntimeError): ...
+
+class Mailer:                                     # ABC
+    def send(self, message: EmailMessage) -> None
+
+class SMTPMailer(Mailer):    # (host, port, username, password, security, timeout)
+class ConsoleMailer(Mailer): # logs the rendered message; dev default
+class NullMailer(Mailer):    # discards; MAIL_ENABLED=false
+class MemoryMailer(Mailer):  # .outbox: list[EmailMessage]; the test fixture
+
+def build_mailer() -> Mailer                      # chooses a backend from config
+```
+
+### `extensions.py` — how routes reach it
+
+```python
+class MailerProxy:
+    def init_app(self, app) -> None               # build_mailer(), store at app.extensions['mailer']
+    def send(self, message: EmailMessage) -> None # delegate to the current app's backend
+    @property
+    def backend(self) -> Mailer
+
+mailer = MailerProxy()                            # beside db / login_manager / limiter
+```
+
+Tests swap a backend with `app.extensions['mailer'] = MemoryMailer()` — no monkeypatching of
+module globals, so it survives the session-scoped `app` fixture.
+
+### `models.py` — invite state
+
+```python
+class InviteState(str, Enum):
+    ACCEPTED, LEGACY, EXPIRED, SEND_FAILED, ISSUED, SENT
+
+class AllowedEmail(Base):
+    @property
+    def state(self) -> InviteState                # evaluated in the §4 order, never stored
+    @property
+    def is_pending(self) -> bool                  # ISSUED | SENT | SEND_FAILED
+```
+
+### `invites.py` — lifecycle (no Flask imports)
+
+```python
+class InviteError(Exception): ...
+class InvalidInvite(InviteError): ...             # no such token
+class ExpiredInvite(InviteError): ...             # past expires_at
+class AlreadyAccepted(InviteError): ...           # consumed
+class ResendTooSoon(InviteError): ...             # inside the cooldown
+
+def hash_token(token: str) -> str                 # sha256 hexdigest, the stored form
+
+def issue(session, email, *, note='', prefill_username='',
+          invited_by_id=None, ttl_hours=INVITE_TTL_HOURS) -> tuple[AllowedEmail, str]
+def rotate(session, invite, *, ttl_hours=INVITE_TTL_HOURS) -> str
+def validate(session, token, *, now=None) -> AllowedEmail
+def consume(session, invite, *, username, password) -> User
+def mark_sent(session, invite, error='') -> None
+def check_resend_allowed(invite, *, cooldown_seconds=INVITE_RESEND_COOLDOWN_SECONDS,
+                         now=None) -> None
+```
+
+`issue` and `rotate` return the **plaintext token exactly once**; it is never readable again.
+`consume` creates the user, stamps `accepted_at` / `accepted_user_id` and nulls `token_hash` in
+one transaction.
+
+### `emails.py` — content
+
+```python
+def build_invite_email(invite, token, *, base_url, from_addr, from_name) -> EmailMessage
+def send_invite(mailer, session, invite, token) -> None
+```
+
+`send_invite` builds, sends, and calls `mark_sent`. On `MailError` it records the error on the
+row **and re-raises**, so the route can flash the truth and offer the copy-link fallback.
+
+### Routes and endpoint names
+
+| Method | Path | Endpoint |
+|---|---|---|
+| `GET` | `/invite/<token>` | `invite_link` — validate, stash in session, redirect |
+| `GET` | `/invite` | `invite_form` |
+| `POST` | `/invite` | `invite_submit` |
+| `POST` | `/admin/invite/<int:entry_id>/resend` | `admin_resend_invite` |
+| `POST` | `/admin/invite/<int:entry_id>/link` | `admin_invite_link` |
+
+Session key: `session['invite_token']`.
+
+---
+
+## 12. Implementation order
+
+Each step leaves the app working and testable.
+
+1. **`mailer.py` + config + `test_mailer.py`.** No app behaviour changes; `ConsoleMailer` is the
+   default so nothing needs SMTP yet.
+2. **Model columns + `_run_migrations()` entries + `AllowedEmail.state` + schema doc.** Additive;
+   every existing row reads as `LEGACY`.
+3. **`invites.py` + lifecycle tests.** Pure domain logic, no routes touched.
+4. **`emails.py` + the two email templates.** Renderable and assertable via `MemoryMailer`.
+5. **Admin routes and panel UI** — issue-on-add, resend, copy-link, state column. At this point
+   invites work end to end while `/register` still exists, so nobody is locked out mid-deploy.
+6. **`/invite` acceptance routes + `register.html` rework + access tests.**
+7. **Remove `/register` and the login-page link** — the one irreversible-feeling step, taken last
+   and only once step 6 is verified in the Docker test container.
+8. **Docs:** `docs/registration_invites.md`, plus CLAUDE.md (env table, rate limits, models,
+   security notes, tests table), `docs/database_schema.md`, `.env.example`, `.env.prod`, compose
+   files, README.

--- a/docs/invite_registration_design.md
+++ b/docs/invite_registration_design.md
@@ -264,7 +264,11 @@ this is the single most important line in the feature.
 
 When SMTP fails, or is not configured at all (a self-hoster who does not want a mail relay),
 the admin needs a way to hand over the link. `POST /admin/invite/<id>/link` **rotates** the
-token and flashes the fresh URL once, with a "copy" button. This makes SMTP genuinely optional
+token and flashes the fresh URL once, with a "copy" button. It deliberately **does not** take the
+resend cooldown: that cooldown exists because sending mail to a third party on request is a
+mail-bomb primitive, and this route sends none. Gating it would disable the SMTP fallback for
+exactly the minute after a failed send — the moment it is most needed. Rotation is still bounded
+by the route's 30/hour limit. This makes SMTP genuinely optional
 rather than a hard dependency of the whole registration system, and it is the thing to reach
 for when an invite lands in someone's spam folder.
 

--- a/docs/invite_registration_design.md
+++ b/docs/invite_registration_design.md
@@ -504,6 +504,23 @@ def check_resend_allowed(invite, *, cooldown_seconds=INVITE_RESEND_COOLDOWN_SECO
 `consume` creates the user, stamps `accepted_at` / `accepted_user_id` and nulls `token_hash` in
 one transaction.
 
+Three behaviours are fixed here because they are seams where independently built modules drift:
+
+* **`rotate` is the only renewal path.** Resend, copy-link, and the *Send invite* button on a
+  `LEGACY` row all call it. `issue` is strictly for an address never seen before.
+* **`rotate` does not clear `last_send_error`.** `mark_sent` does. The correct resend sequence is
+  `check_resend_allowed` → `rotate` → send → `mark_sent(error=...)` **on both outcomes**; skipping
+  it on the failure path leaves `send_count` undercounting and the panel showing no error.
+* **A consumed link is indistinguishable from a typo.** `consume` nulls `token_hash`, so replaying
+  a used link raises `InvalidInvite`, never `AlreadyAccepted`. The acceptance page must word that
+  message for both audiences at once.
+
+**Accepted limitation:** a duplicate address given to `issue`, and a username collision inside
+`consume`, both raise the base `InviteError` rather than a dedicated subclass. Both are backstops
+for a race — §7.1 has the admin route check for an existing `AllowedEmail` first, and the
+acceptance route checks username availability first, exactly as `/register` does today. Two admins
+adding one address in the same second is rare enough that a generic message is the right cost.
+
 ### `emails.py` — content
 
 ```python

--- a/docs/registration_invites.md
+++ b/docs/registration_invites.md
@@ -1,0 +1,248 @@
+# Registration & Invites — Operator Guide
+
+How accounts get created on a PixelVault instance, what the admin panel's buttons do, and
+what to do when an invitation does not arrive.
+
+This is the operations side. The variables themselves are documented in
+[configuration.md §5](configuration.md#5-mail--invites); the reasoning behind the design is in
+[invite_registration_design.md](invite_registration_design.md); the columns are in
+[database_schema.md](database_schema.md#allowedemail--the-invite-lifecycle).
+
+---
+
+## 1. The short version
+
+**There is no sign-up page.** The only way an account comes into existence is:
+
+1. An admin adds an address in **Admin → Allowed Emails**.
+2. The app mints a single-use link and emails it to that address.
+3. The recipient clicks it, picks a username and password, and is signed in.
+
+The link expires on its own after `INVITE_TTL_HOURS` (default 72), stops working the moment it
+is used, and is bound to the address it was issued for — the acceptance form shows that address
+read-only and the server never reads an address from the form. An invitee cannot register under
+a different email than the one you invited, even by editing the page.
+
+If mail is not working, **Copy link** on the invite's row gives you the URL to hand over
+yourself. SMTP is a convenience here, not a dependency.
+
+---
+
+## 2. First-time setup
+
+Registration works with no mail configuration at all — you just have to hand links over
+manually. To make it automatic you need two things set:
+
+```bash
+PUBLIC_BASE_URL=https://photos.example.com   # the origin your users actually type
+SMTP_HOST=smtp.gmail.com                     # plus port/security/credentials
+MAIL_FROM=photos@example.com
+```
+
+`PUBLIC_BASE_URL` is not optional once you send mail, and the app refuses to boot without it
+when `SMTP_HOST` is set. It is where every invite link points. It is configured rather than
+derived from the incoming request on purpose: behind Cloudflare → nginx → Gunicorn, the origin
+Flask would reconstruct comes from forwarded headers, so a spoofed `Host` on the add-email
+request could otherwise put an attacker's domain in front of a real token.
+
+See [configuration.md §5.4](configuration.md#54-gmail-profile) for the Gmail app-password
+profile, which is the usual starting point.
+
+**Verify it before you need it.** Invite yourself at an address you can read, on the real
+deployment, before you invite anybody else. A relay that authenticates but silently drops mail
+looks exactly like a relay that works, right up until the moment someone is waiting for a link.
+
+### Without a relay
+
+| You want | Set | Result |
+|---|---|---|
+| Links printed to the app log | leave `SMTP_HOST` empty | `ConsoleMailer` — read the link out of `docker compose logs` |
+| No mail at all, ever | `MAIL_ENABLED=false` | `NullMailer` — invites are issued, **Copy link** is the only way to deliver them |
+
+Both still need `PUBLIC_BASE_URL` for a link to be composable. Neither is checked at boot, so
+if you run this way and see *"no email could be composed"* on the flash, that is the missing
+variable.
+
+---
+
+## 3. Inviting someone
+
+**Admin → Allowed Emails → add an address.** Two optional fields go with it:
+
+- **Note** — free text for you, shown only in the panel. Who this is, why they were invited.
+- **Suggested username** — pre-fills the acceptance form. It is a suggestion; the invitee can
+  change it. There is deliberately no "make this person an admin" checkbox: a mistyped
+  checkbox on this form must never be able to mint an administrator. Promote a real account
+  by hand afterwards instead.
+
+Adding the address does three things, in this order: it commits the invite row, mints the
+token, and *then* tries to send. The order matters when things go wrong — a relay outage
+leaves a perfectly good invite behind for you to resend or hand over, rather than losing it.
+
+You will get one of these back:
+
+| Flash | Meaning |
+|---|---|
+| *"has been invited — an invitation is on its way"* | Sent. |
+| *"was invited, but the email could not be sent: …"* | The invite exists and its link is live. Delivery failed. Use **Copy link**. |
+| *"already has an account, so there is nothing to invite"* | They can just sign in. |
+| *"has already been invited. Use Resend…"* | There is a row for this address already. |
+
+---
+
+## 4. Reading the panel
+
+Every row carries a badge. The state behind it is computed when the page renders — never
+stored — so an expiry that lapsed overnight shows up without anything having run.
+
+| Badge | What it means | What to do |
+|---|---|---|
+| **accepted** | The account exists. | Nothing. Terminal. |
+| **no invite** | A whitelist entry from before invites existed — no token was ever minted. | **Send invite**, if the address is still someone you want. |
+| **expired** | The link lapsed unused. | **Resend**. |
+| **send failed** | The token is fine; delivery failed. The relay's error is shown on the row. | **Resend**, or **Copy link**. |
+| **not emailed** | A live link nobody has emailed — the result of **Copy link**, or of mail being off. | Hand the link over. |
+| **sent** | Delivered, not yet clicked. | Wait. Then resend past the cooldown. |
+
+The row also shows when it was sent (and how many attempts, past the first), when it expires,
+your note, and the suggested username.
+
+### Deploy day
+
+Every address you had whitelisted before this feature reads as **no invite**. Those
+people can no longer register — the whitelist alone is not a way in any more. Nothing was
+emailed to them on upgrade, deliberately: mailing a year-old list on deploy day is a good way
+to get a sending domain blocked. Go through the rows and press **Send invite** on the ones
+still worth inviting, then delete the rest.
+
+---
+
+## 5. The three buttons
+
+### Resend / Send invite
+
+One button under two labels — it reads **Send invite** on a row that has never been emailed
+(a `no invite` row, or one created by **Copy link**) and **Resend** otherwise. Same route,
+same behaviour.
+
+Mints a **new** token, sends it, and **kills the previous link immediately**. This is not a
+retry — it is a replacement. Anyone still holding the old link gets "this invitation link is
+not valid".
+
+That is a consequence of storing only the hash of a token: the plaintext is unrecoverable, so
+renewal must mint. It is also the safer default, since a resend usually means the first link
+was lost or went somewhere it should not have.
+
+Refused inside `INVITE_RESEND_COOLDOWN_SECONDS` (default 60) of the last send, with the
+remaining wait named in the message. The cooldown is not about your patience: this is mail the
+server sends to a third party on request, and an unthrottled resend button is a mail-bomb
+primitive aimed at whatever address is typed in. The check runs *before* the rotation, so a
+refusal costs the invitee nothing — the link they already hold keeps working.
+
+### Copy link
+
+Rotates the token and shows the URL **once**, in a flash message. Sends no mail, and takes no
+cooldown — gating it would disable the fallback in exactly the minute after a failed send,
+which is the minute it is most needed.
+
+**Copy it before you navigate away.** Only the SHA-256 is stored; closing the page loses the
+link and the only fix is another rotation, which invalidates this one too.
+
+Reach for this when the relay is down, when there is no relay, or when an invite has landed in
+someone's spam folder and a second email will land there too.
+
+### Remove
+
+Deletes the invite row, which is also how you **revoke** an outstanding link — the token hash
+lives on that row, so deleting it makes any link unmatchable on the next lookup. There is no
+separate revoke button because there does not need to be one.
+
+Removing an **accepted** row does *not* delete the account it produced. The row is bookkeeping
+about a past event; `accepted_user_id` has no cascade behind it. Delete the user from the Users
+table if that is what you meant.
+
+---
+
+## 6. What the invitee sees
+
+Clicking the link lands them on the acceptance form with their address filled in and locked,
+and the suggested username (if you set one) filled in and editable. They choose a username and
+a password — same rules as the old sign-up form: 3–64 characters, letters/numbers/hyphens/
+underscores, and a password of at least 8 characters. On submit the account is created and
+they are signed in.
+
+The token does not stay in the address bar. The link validates, moves the token into the signed
+session, and redirects to `/invite` — so the credential does not end up in nginx access logs,
+browser history, or a "here's the page I'm on" message.
+
+If the link does not work they see one of four messages, each naming a different fix:
+
+| They see | Because | Your move |
+|---|---|---|
+| "…has expired. Ask an admin for a new one" | past `INVITE_TTL_HOURS` | Resend. |
+| "…is not valid. Check that you copied the whole link… if you have already used it, sign in" | no such token | Read below. |
+| "…already been accepted and the account exists" | replayed on a row still findable | Tell them to sign in. |
+| "You are already signed in…" | they clicked while logged in as someone else | Log out first. |
+
+**"Not valid" is deliberately ambiguous** and cannot be made specific. Accepting an invite
+nulls the token hash, so a used link and a mistyped link are the same thing to the server —
+nothing matches either way. The message is worded for both readers at once because guessing
+between them would strand whichever reader we guessed against.
+
+Accepting while already signed in is **refused, not merged**. The app will not log someone out
+on the strength of a URL they opened, and it cannot tell whether the signed-in person is the
+invitee.
+
+---
+
+## 7. Troubleshooting
+
+**"was invited, but the email could not be sent"**
+Delivery, not the invite. The row reads **Send failed** with the relay's error on it. Check
+`SMTP_HOST`/`SMTP_PORT`/`SMTP_SECURITY` agree (587 wants `starttls`, 465 wants `ssl`), and that
+`SMTP_PASSWORD` is a Gmail *app password* rather than the account password. Meanwhile, **Copy
+link** gets the person in.
+
+**"no email could be composed"**
+`PUBLIC_BASE_URL` is unset. Nothing was sent; the invite is live and stays that way.
+
+**Sends succeed but nothing arrives**
+Check spam. Mail from a `@gmail.com` sender to strangers lands there routinely — this is the
+argument for a domain with SPF/DKIM, or a transactional provider. Hand this one over with
+**Copy link** and fix the sending domain before the next batch.
+
+**The invite email's link 404s or points at the wrong host**
+`PUBLIC_BASE_URL` does not match the origin users reach. It must be the external origin
+including scheme, no trailing slash — `https://photos.example.com`, not the container's
+internal address and not `http://` on an HTTPS deployment.
+
+**Requests hang when adding an address**
+Sends run synchronously inside the admin request, bounded by `MAIL_TIMEOUT_SECONDS` (default
+10). A wrong port typically shows up as a full-timeout stall rather than an error. Production
+runs 2 workers × 4 threads, so a long timeout on a dead relay ties up an eighth of the server
+per attempt — do not raise it much.
+
+**Someone insists they never got a link and Resend refuses**
+You are inside the cooldown; the message names the seconds remaining. Use **Copy link**, which
+has none.
+
+**A guest with a share link cannot see the album**
+Album routes require an account. They land on the Access Required page, which now names
+`ADMIN_CONTACT` (falling back to `MAIL_FROM`) as who to ask. If both are unset the page tells
+them to ask whoever shared the link — still actionable, but set `ADMIN_CONTACT` if guests are
+common.
+
+---
+
+## 8. Housekeeping
+
+Expired invites are not swept. Nothing breaks — an expired row simply stops working, and the
+state is computed at render time — but the table grows, so delete rows you are done with.
+Removing an accepted row does not touch the account, so an accepted row can be cleared once you
+no longer care to know who invited whom.
+
+The invite endpoints are rate-limited per IP: 60/hour for clicking a link and 20/hour for
+submitting the form. Admin actions are limited per user: 60/hour for adding an address, 30/hour
+each for resend and copy-link. Limits live in per-worker memory and reset on deploy, so they
+damp abuse rather than prevent it — the cooldown is the durable protection against the
+mail-bomb case.

--- a/src/pixelvault/__init__.py
+++ b/src/pixelvault/__init__.py
@@ -204,6 +204,25 @@ def _run_migrations():
                 updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
                 UNIQUE(user_id, album_id, client_key)
             )""",
+            # Invite lifecycle on allowed_email (docs/invite_registration_design.md §4).
+            # Every default here is a literal, because SQLite refuses a non-constant
+            # DEFAULT on ADD COLUMN and would otherwise leave the pre-existing rows
+            # unwritable; the nullable columns carry no default at all, which is what
+            # makes an untouched row read as LEGACY rather than as a broken invite.
+            "ALTER TABLE allowed_email ADD COLUMN token_hash VARCHAR(64)",
+            "ALTER TABLE allowed_email ADD COLUMN token_issued_at DATETIME",
+            "ALTER TABLE allowed_email ADD COLUMN expires_at DATETIME",
+            "ALTER TABLE allowed_email ADD COLUMN prefill_username VARCHAR(64) NOT NULL DEFAULT ''",
+            "ALTER TABLE allowed_email ADD COLUMN last_sent_at DATETIME",
+            "ALTER TABLE allowed_email ADD COLUMN send_count INTEGER NOT NULL DEFAULT 0",
+            "ALTER TABLE allowed_email ADD COLUMN last_send_error VARCHAR(256) NOT NULL DEFAULT ''",
+            "ALTER TABLE allowed_email ADD COLUMN accepted_at DATETIME",
+            "ALTER TABLE allowed_email ADD COLUMN accepted_user_id INTEGER REFERENCES user(id)",
+            "ALTER TABLE allowed_email ADD COLUMN invited_by_id INTEGER REFERENCES user(id)",
+            # Named exactly as SQLAlchemy names the index=True on the column, so a
+            # database created by create_all() and one arrived at by migration end up
+            # with the same schema rather than two indexes doing one job.
+            "CREATE INDEX IF NOT EXISTS ix_allowed_email_token_hash ON allowed_email (token_hash)",
         ]:
             try:
                 conn.execute(db.text(stmt))

--- a/src/pixelvault/__init__.py
+++ b/src/pixelvault/__init__.py
@@ -7,6 +7,12 @@ from werkzeug.middleware.proxy_fix import ProxyFix
 import sys
 
 from .extensions import db, login_manager, limiter
+# Aliased deliberately. Importing the `pixelvault.mailer` *module* — which
+# extensions does, to build a backend — binds it as an attribute of this package,
+# and a package's attributes are this file's globals. An unaliased `mailer` proxy
+# here would therefore be silently replaced by the module object.
+from .extensions import mailer as mailer_ext
+from .mailer import SECURITY_MODES
 from .config import *
 import pixelvault.utils as utils
 import logging
@@ -55,9 +61,11 @@ def create_app():
     app.config['PERMANENT_SESSION_LIFETIME'] = 86400 * 30
 
     # ── Extensions ─────────────────────────────────────────────────────────
+    _validate_mail_config()
     db.init_app(app)
     login_manager.init_app(app)
     limiter.init_app(app)
+    mailer_ext.init_app(app)
     # ── Routes ─────────────────────────────────────────────────────────────
     # Import after extensions are bound so decorators resolve correctly
     from .routes import register_all
@@ -123,6 +131,47 @@ def create_app():
         _run_migrations()
 
     return app
+
+
+def _validate_mail_config():
+    """Refuse to boot on a mail configuration that would fail only at send time.
+
+    Every combination checked here produces an invite that is *issued* — the row
+    is committed before the send is attempted — and then either undeliverable or,
+    worse, deliverable but carrying a link to nowhere. Both faults surface hours
+    later, to an admin who has already told someone to expect an email, so they
+    are worth a loud crash on deploy instead.
+
+    Silence is deliberate for the unconfigured case: a dev checkout with no SMTP
+    at all must still boot, on ConsoleMailer. This only fires once an operator has
+    started configuring a relay and stopped halfway.
+    """
+    if not MAIL_ENABLED or not SMTP_HOST:
+        return  # nothing is being sent; there is nothing to be incoherent about
+
+    if SMTP_SECURITY not in SECURITY_MODES:
+        raise RuntimeError(
+            f"SMTP_SECURITY={SMTP_SECURITY!r} is not valid. "
+            f"Set it to one of: {', '.join(SECURITY_MODES)} "
+            "(587 normally wants 'starttls', 465 wants 'ssl')."
+        )
+
+    if not MAIL_FROM:
+        raise RuntimeError(
+            "SMTP_HOST is configured but MAIL_FROM is empty, so every message would be "
+            "rejected by the relay for having no sender. Set MAIL_FROM to the address "
+            "mail is sent from — with Gmail it must be the SMTP_USERNAME account itself, "
+            "because Google rewrites a From it does not own. "
+            "Set MAIL_ENABLED=false if you did not mean to send mail at all."
+        )
+
+    if not PUBLIC_BASE_URL:
+        raise RuntimeError(
+            "SMTP_HOST is configured but PUBLIC_BASE_URL is empty. Invite links are built "
+            "from that value rather than from the request's Host header, so without it "
+            "there is no origin to point an invite at. Set it to the canonical external "
+            "URL, e.g. PUBLIC_BASE_URL=https://photos.example.com."
+        )
 
 
 def _run_migrations():

--- a/src/pixelvault/config.py
+++ b/src/pixelvault/config.py
@@ -65,3 +65,48 @@ MAX_INFLIGHT_UPLOAD_BYTES_PER_USER = int(os.environ.get('MAX_INFLIGHT_UPLOAD_MB_
 # the region ProxyFix trusts, letting a caller name any IP it likes and so
 # choose its own rate-limit bucket. When unsure, set it too low.
 TRUSTED_PROXY_COUNT = int(os.environ.get('TRUSTED_PROXY_COUNT', 1))
+
+# ── Mail & invites (docs/configuration.md) ─────────────────────────────────
+# The canonical external origin invite links are built from, e.g.
+# "https://photos.example.com". Deliberately configured rather than derived
+# from url_for(_external=True): behind Cloudflare -> nginx -> Gunicorn the
+# reconstructed URL is only as trustworthy as the forwarded headers, so an
+# attacker-controlled Host on the add-email request could otherwise point an
+# invite link at a domain they own. Stored without a trailing slash so callers
+# can concatenate a path without guessing.
+PUBLIC_BASE_URL = os.environ.get('PUBLIC_BASE_URL', '').strip().rstrip('/')
+
+# false -> NullMailer: invites are still issued and their links are still
+# usable via the admin copy-link fallback, but nothing leaves the process.
+MAIL_ENABLED = os.environ.get('MAIL_ENABLED', 'true').lower() == 'true'
+
+# Unset -> ConsoleMailer, so a dev checkout boots and prints invite links to
+# the log instead of demanding a relay.
+SMTP_HOST = os.environ.get('SMTP_HOST', '').strip()
+SMTP_PORT = int(os.environ.get('SMTP_PORT', 587))
+SMTP_USERNAME = os.environ.get('SMTP_USERNAME', '').strip()
+# Not stripped: a password may legitimately begin or end with a space, and
+# Gmail app passwords are usually pasted with the grouping spaces intact.
+SMTP_PASSWORD = os.environ.get('SMTP_PASSWORD', '')
+# 'starttls' (587, upgrade in band) | 'ssl' (465, TLS from the first byte) |
+# 'none' (plaintext; only defensible for a relay on localhost).
+SMTP_SECURITY = os.environ.get('SMTP_SECURITY', 'starttls').strip().lower()
+
+MAIL_FROM = os.environ.get('MAIL_FROM', '').strip()
+MAIL_FROM_NAME = os.environ.get('MAIL_FROM_NAME', 'PixelVault').strip()
+# Socket timeout for the whole SMTP conversation. Sends happen synchronously
+# inside the admin request, and production runs 2 workers x 4 threads — without
+# a bound, one hung relay holds an eighth of the server until the OS gives up.
+MAIL_TIMEOUT_SECONDS = int(os.environ.get('MAIL_TIMEOUT_SECONDS', 10))
+
+# Address shown to accountless share-link guests so they know who to ask for an
+# invitation. Falls back to the sending address, which is nearly always right.
+ADMIN_CONTACT = os.environ.get('ADMIN_CONTACT', '').strip() or MAIL_FROM
+
+# Invite link lifetime, measured from issue or rotation. Consumed by invites.py.
+INVITE_TTL_HOURS = int(os.environ.get('INVITE_TTL_HOURS', 72))
+# Minimum gap between two sends of one invite. Not an anti-annoyance measure:
+# an invite is mail this server sends to a third party on request, so an
+# unthrottled resend button is a mail-bomb primitive aimed at whatever address
+# was typed in — and it burns the sending domain's reputation with the relay.
+INVITE_RESEND_COOLDOWN_SECONDS = int(os.environ.get('INVITE_RESEND_COOLDOWN_SECONDS', 60))

--- a/src/pixelvault/emails.py
+++ b/src/pixelvault/emails.py
@@ -1,0 +1,192 @@
+"""Message composition — turning an invite into something a person can read.
+
+The third of the three concerns the mail feature is split into, and the smallest.
+``mailer.py`` knows how to put an ``EmailMessage`` on the wire and nothing about
+what is in it; ``invites.py`` owns the credential's lifecycle and never renders;
+this module is the only place that knows an invite has *wording*. Swapping SMTP
+for a provider's HTTP API touches ``mailer.py`` alone, and rewording the invite
+touches ``templates/email/`` alone — neither edit can reach the other.
+
+Three rules here are load-bearing rather than stylistic:
+
+* **The text part is authored first.** The message is ``multipart/alternative``
+  and the HTML is garnish. A client picks the last part it understands, so a
+  malformed HTML part costs nothing that matters as long as the plain-text one
+  still carries a complete, clickable URL. That ordering is why
+  :func:`build_invite_email` calls ``set_content`` before ``add_alternative``.
+* **The link is built from a configured origin, never from the request.** Behind
+  Cloudflare -> nginx -> Gunicorn the URL ``url_for(_external=True)`` reconstructs
+  is only as trustworthy as the forwarded headers, so an attacker-controlled
+  ``Host`` on the *add-email* request would otherwise steer a real invite — sent
+  by this server, to a real person, over a genuine address — at a domain they own.
+  ``PUBLIC_BASE_URL`` removes the question (design §6).
+* **Nothing token-shaped is ever logged**, the same rule ``mailer.py`` and
+  ``invites.py`` run under. The token creates an account bound to someone's email
+  address; a copy in a log file is a copy of the credential. Log lines here carry
+  the invite id and the address, never the secret and never the body.
+
+See docs/invite_registration_design.md §6 and §13.
+"""
+
+import logging
+from datetime import datetime
+from email.headerregistry import Address
+from email.message import EmailMessage
+from email.utils import formatdate, make_msgid
+
+from flask import render_template
+
+from . import invites
+from .config import MAIL_FROM, MAIL_FROM_NAME, PUBLIC_BASE_URL
+from .mailer import MailError
+
+logger = logging.getLogger(__name__)
+
+#: Subject line for the invite. Kept here rather than in the templates because a
+#: subject is a header, not body copy — it has to be set on the message before
+#: either part exists, and it must read identically whichever part a client shows.
+INVITE_SUBJECT = 'You have been invited to PixelVault'
+
+#: Path the invite token is presented at. Must match the ``invite_link`` route in
+#: design §13's endpoint table; the email is written before that route exists, so
+#: this constant is the only place the two can drift.
+INVITE_PATH = '/invite'
+
+
+# ── Human-readable expiry ──────────────────────────────────────────────────
+
+def _format_expiry(expires_at: datetime) -> str:
+    """Render an expiry instant as a date a person can act on.
+
+    Explicitly labelled UTC, because that is what the column holds and an
+    unlabelled time is worse than none — an invitee in UTC+10 reading a bare
+    "14:00" has been told the wrong thing, not an ambiguous thing.
+
+    ``%d`` is avoided so the day is not zero-padded; the ``%-d`` that would do
+    that directly is glibc-only and would break the moment anyone runs this on a
+    non-Linux host.
+    """
+    return f"{expires_at.day} {expires_at:%B %Y} at {expires_at:%H:%M} UTC"
+
+
+def _humanise_remaining(expires_at: datetime, now: datetime) -> str:
+    """Render the time left as a rough duration, or ``''`` if there is none.
+
+    Deliberately coarse. The exact figure is stale the moment the message is
+    queued, and "about 3 days" survives an hour in a relay's retry queue in a way
+    "in 71 hours and 48 minutes" does not. The absolute timestamp beside it is the
+    precise statement; this is the one that gets read.
+
+    Empty for an expiry already in the past so the templates can drop the phrase
+    rather than promise time that does not exist.
+    """
+    seconds = (expires_at - now).total_seconds()
+    if seconds <= 0:
+        return ''
+    if seconds < 3600:
+        return 'less than an hour'
+    hours = round(seconds / 3600)
+    if hours < 48:
+        return f"about {hours} hour{'s' if hours != 1 else ''}"
+    days = round(seconds / 86400)
+    return f"about {days} day{'s' if days != 1 else ''}"
+
+
+# ── Composition ────────────────────────────────────────────────────────────
+
+def build_invite_email(invite, token, *, base_url=PUBLIC_BASE_URL,
+                       from_addr=MAIL_FROM, from_name=MAIL_FROM_NAME) -> EmailMessage:
+    """Compose the invite message for ``invite``, carrying the plaintext ``token``.
+
+    Returns a ``multipart/alternative`` message with the plain-text part first and
+    the HTML part second, both rendered from ``templates/email/invite.*`` through
+    the app's Jinja environment — so the copy is reviewable as text in the same
+    place as every other template, and needs an app context to build.
+
+    ``base_url`` defaults to ``PUBLIC_BASE_URL`` and is the *only* source of the
+    link's origin; it is a parameter so a caller can be explicit and a test can
+    prove the value is not coming from a request. The path is ``/invite/<token>``.
+
+    Raises ``ValueError`` if the invite has no ``expires_at``. That combination is
+    not reachable through :mod:`~pixelvault.invites` — ``_mint`` writes the token
+    and both timestamps together — so it means a hand-edited or corrupted row, and
+    ``validate`` will refuse the link anyway. Sending it would deliver a dead link
+    with no expiry stated on it, which is exactly the silent failure this email
+    exists to prevent; failing here is the loud version.
+    """
+    if not base_url:
+        raise ValueError(
+            "PUBLIC_BASE_URL is unset, so an invite link would have no origin. "
+            "See docs/configuration.md."
+        )
+    if invite.expires_at is None:
+        raise ValueError(
+            f"Invite {invite.id} has no expires_at; refusing to send a link "
+            "that cannot state when it stops working."
+        )
+
+    invite_url = f"{base_url.rstrip('/')}{INVITE_PATH}/{token}"
+    context = {
+        'invite_url': invite_url,
+        'email': invite.email,
+        'site_url': base_url.rstrip('/'),
+        'username': invite.prefill_username or '',
+        'expires_at_text': _format_expiry(invite.expires_at),
+        'expires_in_text': _humanise_remaining(invite.expires_at, datetime.utcnow()),
+    }
+
+    message = EmailMessage()
+    message['Subject'] = INVITE_SUBJECT
+    # Address() rather than a hand-built "Name <addr>" string: it encodes a display
+    # name containing a comma, a quote or a non-ASCII character correctly, and a
+    # broken From is a message the relay rejects outright.
+    local, _, domain = from_addr.partition('@')
+    message['From'] = Address(display_name=from_name, username=local, domain=domain)
+    message['To'] = invite.email
+    # Date and Message-ID are set here rather than left to the relay. Both are
+    # absent-header spam signals, and an invite is precisely the mail that must not
+    # land in a spam folder. The Message-ID domain is the sender's, so the host's
+    # internal name — which is what make_msgid() would otherwise use — stays private.
+    message['Date'] = formatdate(localtime=True)
+    message['Message-ID'] = make_msgid(domain=domain or None)
+
+    # Text first, HTML second. set_content makes the plain part the body; the
+    # add_alternative call is what promotes the message to multipart/alternative
+    # with that part already in place. Reversing these two lines would put the
+    # garnish where the guaranteed-readable copy belongs.
+    message.set_content(render_template('email/invite.txt', **context))
+    message.add_alternative(render_template('email/invite.html', **context),
+                            subtype='html')
+    return message
+
+
+def send_invite(mailer, session, invite, token) -> None:
+    """Build the invite email, send it, and record the attempt on the row either way.
+
+    ``mailer`` is anything with ``Mailer.send`` — in a route that is the
+    ``extensions.mailer`` proxy, in a test a ``MemoryMailer``.
+
+    The bookkeeping is the part worth reading. :func:`invites.mark_sent` is called
+    on **both** outcomes, per design §13: it counts *attempts*, so skipping it on
+    the failure path would leave ``send_count`` undercounting and — worse — leave
+    ``last_send_error`` empty, so the row would read SENT and the admin panel would
+    show a delivered invite that never arrived. On success the same call clears any
+    error left by an earlier attempt, which is what moves a SEND_FAILED row to SENT
+    after a resend works.
+
+    ``MailError`` is re-raised once the row is stamped, so the route can flash the
+    real reason and offer the copy-link fallback (§7.3). Nothing is swallowed here:
+    this module has no view on what an admin should be told.
+    """
+    message = build_invite_email(invite, token)
+    try:
+        mailer.send(message)
+    except MailError as exc:
+        # str(exc) is the relay's complaint, which mailer.py builds from the fault
+        # alone and never from the message — so it is safe to store and render.
+        # Truncation to the column width happens inside mark_sent.
+        invites.mark_sent(session, invite, error=str(exc))
+        raise
+
+    invites.mark_sent(session, invite)
+    logger.info("Invite %s emailed to %s", invite.id, invite.email)

--- a/src/pixelvault/extensions.py
+++ b/src/pixelvault/extensions.py
@@ -1,6 +1,6 @@
 import sqlite3
 
-from flask import flash, jsonify, request
+from flask import current_app, flash, jsonify, request
 from flask_sqlalchemy import SQLAlchemy
 from flask_login import LoginManager, current_user
 from flask_login.utils import login_url
@@ -127,3 +127,33 @@ limiter = Limiter(
     default_limits=["200 per hour"],
     storage_uri="memory://",
 )
+
+
+class MailerProxy:
+    """App-bound handle on the mail transport, in the shape of db / login_manager / limiter.
+
+    The concrete backend is chosen once per app by :func:`~pixelvault.mailer.build_mailer`
+    and parked in ``app.extensions['mailer']``; this proxy resolves it per call
+    through ``current_app``. That indirection is what lets a test write
+    ``app.extensions['mailer'] = MemoryMailer()`` and have every caller pick it up
+    — including callers that imported ``mailer`` at module load, which is all of
+    them, and which is why swapping a module global would not work under the
+    session-scoped ``app`` fixture.
+    """
+
+    def init_app(self, app):
+        """Build the configured backend and register it on ``app``."""
+        from pixelvault.mailer import build_mailer
+        app.extensions['mailer'] = build_mailer()
+
+    @property
+    def backend(self):
+        """The current app's mail backend."""
+        return current_app.extensions['mailer']
+
+    def send(self, message):
+        """Deliver ``message`` through the current app's backend; raises ``MailError``."""
+        return self.backend.send(message)
+
+
+mailer = MailerProxy()

--- a/src/pixelvault/extensions.py
+++ b/src/pixelvault/extensions.py
@@ -114,8 +114,8 @@ def rate_limit_key():
     the routes that carry real cost this sidesteps the reverse-proxy question
     entirely (see TRUSTED_PROXY_COUNT in config.py and issue #30).
 
-    The IP fallback is still correct where it is used: /register and /login run
-    before the caller has any identity to key on.
+    The IP fallback is still correct where it is used: /login and the /invite
+    acceptance routes run before the caller has any identity to key on.
     """
     if current_user.is_authenticated:
         return f"user:{current_user.id}"

--- a/src/pixelvault/invites.py
+++ b/src/pixelvault/invites.py
@@ -1,0 +1,371 @@
+"""Invite lifecycle — issuing, rotating, validating and consuming registration links.
+
+An ``AllowedEmail`` row is two facts at once: the whitelist entry that permits an
+address to register, and the bearer credential that carries that permission to a
+person. This module owns the second half — minting a token, deciding whether a
+presented one is still good, and turning it into exactly one account.
+
+It is deliberately free of Flask. Nothing here imports ``request``, flashes, or
+aborts, for the same reason ``uploads.py`` does not: the rules below have to hold
+identically for an admin request, a CLI command and a test with no HTTP client at
+all, and they are far easier to audit when they are not interleaved with rendering.
+The routes in steps 5 and 6 decide presentation; every fault here surfaces as an
+:class:`InviteError` subclass and they map it.
+
+Two invariants earn most of the comments in this file:
+
+* **The plaintext token exists exactly once.** :func:`issue` and :func:`rotate`
+  return it and then it is gone — only its SHA-256 is stored. That is what makes a
+  leaked database backup or a screenshot of the admin panel useless, and it is also
+  why a resend cannot re-show the old link and must mint a new one instead.
+* **Nothing token-shaped is ever logged.** The token creates an account bound to a
+  real person's email address; a copy in a log file is a copy of the credential.
+  Log lines here carry the invite id and the address, never the secret.
+
+See docs/invite_registration_design.md §4 (token handling), §7 (request flows) and
+§13 (the signatures below, which are a contract with the modules built around them).
+"""
+
+import hashlib
+import hmac
+import logging
+import math
+import secrets
+from datetime import datetime, timedelta
+
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+
+from .config import INVITE_RESEND_COOLDOWN_SECONDS, INVITE_TTL_HOURS
+from .models import AllowedEmail, User
+
+logger = logging.getLogger(__name__)
+
+#: Bytes of entropy per token. 32 bytes is 256 bits, rendered by
+#: ``secrets.token_urlsafe`` as 43 URL-safe characters.
+TOKEN_BYTES = 32
+
+#: ``AllowedEmail.last_send_error`` is ``String(256)``, and SQLite does not enforce
+#: VARCHAR length — an over-long relay error would be stored in full and then
+#: silently break on a backend that does enforce it. Truncation happens here so
+#: every writer gets it, rather than at each call site.
+MAX_SEND_ERROR_LEN = 256
+
+
+class InviteError(Exception):
+    """Base for every invite fault. Routes catch this and choose the wording."""
+
+
+class InvalidInvite(InviteError):
+    """No live invite matches the presented token.
+
+    Covers a garbage or guessed token, a link from a database that has since been
+    reset, and — because :func:`consume` nulls ``token_hash`` — a token that was
+    already used. The last case is worth knowing about at the route layer: a
+    consumed link is unrecoverable by design, so it cannot be told apart from a
+    typo and the acceptance page has to word this one for both.
+    """
+
+
+class ExpiredInvite(InviteError):
+    """The token is real but its TTL has run out. The fix is rotate-and-resend."""
+
+
+class AlreadyAccepted(InviteError):
+    """This invite has already produced an account.
+
+    Raised by :func:`consume` when a double-submit or a shared link loses the race,
+    and by :func:`rotate` because acceptance is terminal — re-minting a token there
+    would reopen a flow that is finished.
+    """
+
+
+class ResendTooSoon(InviteError):
+    """Another send was attempted inside ``INVITE_RESEND_COOLDOWN_SECONDS``.
+
+    Carries :attr:`seconds_remaining` so the caller can say *when* rather than just
+    *no*. The cooldown is not about admin patience: an invite is mail this server
+    sends to a third party on request, so an unthrottled resend button is a
+    mail-bomb primitive pointed at whatever address was typed in.
+    """
+
+    def __init__(self, seconds_remaining):
+        seconds_remaining = max(0, int(seconds_remaining))
+        super().__init__(
+            f"An invite was just sent; wait {seconds_remaining}s before sending another."
+        )
+        self.seconds_remaining = seconds_remaining
+
+
+# ── Tokens ─────────────────────────────────────────────────────────────────
+
+def hash_token(token: str) -> str:
+    """Return the stored form of an invite token: a plain SHA-256 hexdigest.
+
+    Plain SHA-256 and not bcrypt, deliberately. A password hash is slow to defeat
+    guessing a human-chosen secret from a dictionary; there is no dictionary here,
+    because the token is 256 bits from ``secrets``. Slowing the hash would only
+    slow the one legitimate lookup on every click.
+
+    The exact form is load-bearing beyond this module: the column is ``String(64)``,
+    which fits a hexdigest and nothing longer.
+    """
+    return hashlib.sha256(token.encode()).hexdigest()
+
+
+def _mint(invite, ttl_hours, now=None):
+    """Stamp a fresh token onto ``invite`` and return the plaintext, once.
+
+    The three columns move together on purpose. ``AllowedEmail.state`` reads
+    ``expires_at`` directly and never re-derives it from ``token_issued_at``, so a
+    row carrying a token with a NULL ``expires_at`` would report ISSUED or SENT
+    forever — an immortal credential that the admin panel swears is fine. Keeping
+    the assignment in one private function is what stops a future caller from
+    setting two of the three.
+    """
+    now = now or datetime.utcnow()
+    token = secrets.token_urlsafe(TOKEN_BYTES)
+    invite.token_hash = hash_token(token)
+    invite.token_issued_at = now
+    invite.expires_at = now + timedelta(hours=ttl_hours)
+    return token
+
+
+# ── Issuing ────────────────────────────────────────────────────────────────
+
+def issue(session, email, *, note='', prefill_username='',
+          invited_by_id=None, ttl_hours=INVITE_TTL_HOURS):
+    """Authorize ``email`` and mint its first invite; return ``(invite, plaintext_token)``.
+
+    For an address the app has never seen. An address that already has a row — an
+    expired invite, a delivery failure, or a LEGACY whitelist entry from before
+    invites existed — is renewed with :func:`rotate` instead, which is also what
+    the admin panel's *Resend* and *Send invite* buttons call.
+
+    The address is normalised here rather than trusted from the caller. It is the
+    lookup key for the whole whitelist and, after acceptance, the account's
+    identity; letting ``Alice@Example.com `` and ``alice@example.com`` become two
+    rows would mean an invite that silently authorizes a second address.
+
+    The row is committed before anything is emailed (design §7.1), so an invite
+    survives a relay outage and stays resendable.
+
+    Raises :class:`InviteError` if the address already has a row. That is a
+    backstop for two admins clicking at once — the route checks first and offers
+    resend — not a flow anyone should reach by design.
+    """
+    email = (email or '').strip().lower()
+    invite = AllowedEmail(
+        email=email,
+        note=note,
+        prefill_username=prefill_username,
+        invited_by_id=invited_by_id,
+    )
+    token = _mint(invite, ttl_hours)
+    session.add(invite)
+    try:
+        session.commit()
+    except IntegrityError:
+        # Unique on `email`. Roll back so the caller's session is usable — an
+        # un-rolled-back failed flush poisons every later statement on it.
+        session.rollback()
+        raise InviteError(f"{email} has already been invited.")
+
+    logger.info("Issued invite %s for %s", invite.id, invite.email)
+    return invite, token
+
+
+def rotate(session, invite, *, ttl_hours=INVITE_TTL_HOURS):
+    """Mint a replacement token for an existing invite and return the plaintext, once.
+
+    Every renewal path goes through here: *Resend*, the copy-link fallback, and
+    *Send invite* on a LEGACY row that never had a token at all. The old link stops
+    working the moment this commits.
+
+    That the old link dies is a consequence of hashing rather than a feature choice
+    — a link cannot be re-shown, so renewal has to mint — but it is the safer
+    default anyway: a resend usually means the first link was lost or went
+    somewhere it should not have.
+
+    ``send_count`` and ``last_send_error`` are left alone. The count is history the
+    admin panel reports ("resent 4x, still not accepted"), and the error is still
+    an accurate statement about the last delivery attempt until another one
+    happens; :func:`mark_sent` clears it when one succeeds.
+
+    Raises :class:`AlreadyAccepted` if the invite has been consumed — acceptance is
+    terminal, and reopening it would put a live credential on a finished row.
+    """
+    if invite.accepted_at is not None:
+        raise AlreadyAccepted(f"{invite.email} has already registered.")
+
+    token = _mint(invite, ttl_hours)
+    session.commit()
+    logger.info("Rotated invite %s for %s", invite.id, invite.email)
+    return token
+
+
+# ── Validation ─────────────────────────────────────────────────────────────
+
+def validate(session, token, *, now=None):
+    """Return the invite a presented token belongs to, or raise why it cannot be used.
+
+    The three refusals are distinct because the acceptance page gives different
+    advice for each: :class:`InvalidInvite` ("check the link"),
+    :class:`ExpiredInvite` ("ask for a new one") and :class:`AlreadyAccepted`
+    ("you already have an account — sign in").
+
+    Called on both halves of acceptance. The GET's verdict is never carried over to
+    the POST: the invite can expire, be rotated, or be consumed by another tab in
+    between, and only re-validating catches that.
+    """
+    now = now or datetime.utcnow()
+    if not token:
+        raise InvalidInvite("No invite token was presented.")
+
+    presented = hash_token(token)
+    # An indexed equality match on the hash, so this is one index probe rather than
+    # a scan. Guessing is not a threat model worth defending here — 256 bits means
+    # an attacker's odds are indistinguishable from zero however many times they
+    # try, and the endpoint is rate-limited on top — so the query is allowed to be
+    # an ordinary lookup.
+    invite = session.execute(
+        select(AllowedEmail).where(AllowedEmail.token_hash == presented)
+    ).scalar_one_or_none()
+    if invite is None:
+        raise InvalidInvite("This invite link is not valid.")
+
+    # Constant-time on the final compare even though the row was already found by
+    # equality on the same value. It costs one comparison of 64 hex characters and
+    # removes the question entirely, which is cheaper than having to reason about
+    # whether some future backend's index lookup leaks a prefix through timing.
+    if not hmac.compare_digest(invite.token_hash, presented):
+        raise InvalidInvite("This invite link is not valid.")
+
+    # Checked in the same order as AllowedEmail.state, so the admin panel and the
+    # acceptance page can never disagree about which fault a row has.
+    if invite.accepted_at is not None:
+        raise AlreadyAccepted(f"{invite.email} has already registered.")
+
+    # A token with no expiry is a row this module never writes — `_mint` sets all
+    # three columns together — so it is corruption or a hand-edited database.
+    # Refused rather than honoured: the failure mode of trusting it is a bearer
+    # credential that never dies.
+    if invite.expires_at is None or now >= invite.expires_at:
+        # Inclusive, matching AllowedEmail.state. A strict `>` would open a window
+        # in which the panel reports EXPIRED and the link still works.
+        raise ExpiredInvite("This invite link has expired.")
+
+    return invite
+
+
+# ── Acceptance ─────────────────────────────────────────────────────────────
+
+def consume(session, invite, *, username, password):
+    """Create the account this invite authorizes and burn the invite. Returns the ``User``.
+
+    The email comes from ``invite.email`` and from nowhere else. This is the single
+    most important line in the feature: taking it from a submitted form would let
+    the holder of an invite for one address register as another and defeat the
+    whitelist entirely.
+
+    ``username`` and ``password`` are the caller's to validate for shape — the
+    route already does exactly that, and duplicating the rules here would mean two
+    places to change them.
+
+    Everything lands in **one transaction**: insert the user, flush to learn its id,
+    stamp ``accepted_at`` / ``accepted_user_id``, null ``token_hash``. One commit is
+    what makes a crash safe. Split across two, a crash between them leaves either an
+    account beside a still-live link that can be replayed, or a burnt invite with no
+    account and an invitee who is now locked out with nothing to click.
+
+    Raises :class:`AlreadyAccepted` when a double-submit or a shared link loses the
+    race, :class:`ExpiredInvite` / :class:`InvalidInvite` if the invite is not
+    usable, and :class:`InviteError` if the username collides with an existing
+    account.
+    """
+    if invite.accepted_at is not None:
+        raise AlreadyAccepted(f"{invite.email} has already registered.")
+    if invite.token_hash is None:
+        raise InvalidInvite("This address has no live invite.")
+    if invite.expires_at is None or datetime.utcnow() >= invite.expires_at:
+        raise ExpiredInvite("This invite link has expired.")
+
+    invite_id = invite.id
+    email = invite.email
+
+    user = User(username=username, email=email)
+    user.set_password(password)  # the model owns the hashing parameters, not this module
+    session.add(user)
+    try:
+        # Flush rather than commit: the id is needed for accepted_user_id, and the
+        # transaction must stay open until the invite is burnt in it too.
+        session.flush()
+        invite.accepted_at = datetime.utcnow()
+        invite.accepted_user_id = user.id
+        # Nulling the hash is what enforces single use. Safe even though a tokenless
+        # row otherwise reads LEGACY, because ACCEPTED is tested first (design §4).
+        invite.token_hash = None
+        session.commit()
+    except IntegrityError:
+        session.rollback()
+        # The unique constraint on `user.email` is what decides a race: two consumes
+        # of one invite necessarily agree on the address, so the second insert
+        # cannot land whatever username it chose. Re-read the row to tell that apart
+        # from a plain username collision, because the two need opposite advice —
+        # "sign in" versus "pick another name".
+        current = session.get(AllowedEmail, invite_id)
+        if current is not None and current.accepted_at is not None:
+            raise AlreadyAccepted(f"{email} has already registered.")
+        raise InviteError("That username is already taken.")
+
+    logger.info("Invite %s accepted by %s as user %s", invite_id, email, user.id)
+    return user
+
+
+# ── Delivery bookkeeping ───────────────────────────────────────────────────
+
+def mark_sent(session, invite, error=''):
+    """Record that a send was attempted, whether or not the relay accepted it.
+
+    Called on both outcomes. ``send_count`` counts attempts rather than successes,
+    because "resent 4x, still not accepted" is the thing an admin needs to see, and
+    an attempt that failed is exactly the one worth counting.
+
+    A **successful** send clears ``last_send_error`` back to ``''``. Without that a
+    row that failed once reads SEND_FAILED forever, so a later successful resend
+    leaves the panel telling the admin to keep retrying a delivery that already
+    worked.
+
+    ``error`` is truncated to fit the column. It is rendered back to the admin and
+    may reach a log, so callers must pass the relay's complaint and never anything
+    from the message body.
+    """
+    invite.last_sent_at = datetime.utcnow()
+    invite.send_count = (invite.send_count or 0) + 1
+    invite.last_send_error = (error or '')[:MAX_SEND_ERROR_LEN]
+    session.commit()
+    if error:
+        logger.warning("Invite %s to %s failed to send", invite.id, invite.email)
+
+
+def check_resend_allowed(invite, *, cooldown_seconds=INVITE_RESEND_COOLDOWN_SECONDS,
+                         now=None):
+    """Raise :class:`ResendTooSoon` if this invite was sent within the cooldown.
+
+    A pure check — it takes no session and writes nothing, so a route can ask
+    before it does any of the work a send involves.
+
+    An invite that has never been sent is always allowed, which is what makes the
+    first send after a copy-link handover, and the *Send invite* on a LEGACY row,
+    immediate rather than mysteriously refused.
+    """
+    if invite.last_sent_at is None:
+        return
+
+    now = now or datetime.utcnow()
+    elapsed = (now - invite.last_sent_at).total_seconds()
+    remaining = cooldown_seconds - elapsed
+    if remaining > 0:
+        # Rounded up: reporting "0 seconds" while still refusing sends the admin
+        # back to a button that will refuse again.
+        raise ResendTooSoon(math.ceil(remaining))

--- a/src/pixelvault/mailer.py
+++ b/src/pixelvault/mailer.py
@@ -1,0 +1,194 @@
+"""Outbound mail transport — the app's only side effect that leaves the process.
+
+This module knows how to put an ``EmailMessage`` on the wire and nothing else. It
+has never heard of invites, users or albums, which is what lets the next feature
+that needs email (password reset, notifications) reuse it unchanged, and what
+keeps a relay migration to a provider's HTTP API down to one new ``Mailer``
+subclass plus one line in :func:`build_mailer`.
+
+Composition of the message lives in ``emails.py``; the lifecycle that decides a
+message is warranted lives in ``invites.py``. Nothing here flashes, aborts, or
+retries — every failure surfaces as :class:`MailError` and the caller decides.
+
+**Nothing in this module may log a message body.** An invite token is a bearer
+credential that creates an account bound to a real person's email address, and it
+travels in the body; a copy of it in a log file, an aggregator, or a crash report
+is a copy of the credential. Recipient and subject are the most any log line here
+carries. :class:`ConsoleMailer` is the one deliberate exception, and only because
+its console *is* the mailbox — see its docstring.
+"""
+
+import logging
+import smtplib
+import ssl
+from email.message import EmailMessage
+
+from .config import (
+    MAIL_ENABLED,
+    MAIL_TIMEOUT_SECONDS,
+    SMTP_HOST,
+    SMTP_PASSWORD,
+    SMTP_PORT,
+    SMTP_SECURITY,
+    SMTP_USERNAME,
+)
+
+logger = logging.getLogger(__name__)
+
+#: Accepted values for ``SMTP_SECURITY``. Validated at construction rather than at
+#: send time so a typo in ``.env`` is a boot failure, not a failed invite months later.
+SECURITY_MODES = ('starttls', 'ssl', 'none')
+
+
+class MailError(RuntimeError):
+    """Delivery failed. Wraps every ``smtplib``/socket fault this module can hit.
+
+    Callers are expected to catch this and nothing else — a raw ``SMTPException``
+    or ``OSError`` escaping would push relay-specific error handling up into the
+    routes, which is exactly the coupling this module exists to prevent.
+    """
+
+
+class Mailer:
+    """Interface every transport implements: hand it a message, it delivers or raises."""
+
+    def send(self, message: EmailMessage) -> None:
+        """Deliver ``message``, or raise :class:`MailError`."""
+        raise NotImplementedError
+
+
+class SMTPMailer(Mailer):
+    """Sends over SMTP. Relay-agnostic: host, port, credentials and TLS mode all come from config.
+
+    Gmail, Postmark and a relay on localhost differ only in those values, so
+    switching between them is an ``.env`` edit and no code change. Keep it that
+    way — nothing above :func:`build_mailer` should be able to tell which relay is
+    in use.
+
+    A fresh connection per send. Invites are rare and admin-triggered, so pooling
+    would trade a real risk (a stale socket surfacing as a failed invite the admin
+    has to diagnose) for throughput this app has no use for.
+    """
+
+    def __init__(self, host, port=587, username='', password='',
+                 security='starttls', timeout=MAIL_TIMEOUT_SECONDS):
+        if security not in SECURITY_MODES:
+            raise ValueError(
+                f"SMTP_SECURITY must be one of {', '.join(SECURITY_MODES)}; got {security!r}"
+            )
+        self.host = host
+        self.port = port
+        self.username = username
+        self.password = password
+        self.security = security
+        self.timeout = timeout
+
+    def send(self, message: EmailMessage) -> None:
+        """Open a connection, authenticate if credentials are configured, and send.
+
+        The timeout is the *socket* timeout, applied to every step of the
+        conversation including the initial connect. It is load-bearing: sends run
+        synchronously inside the admin's request and production is 2 workers x 4
+        threads, so an unbounded send against a relay that accepts the TCP
+        connection and then goes quiet holds an eighth of the server hostage until
+        the kernel gives up — minutes, not seconds.
+        """
+        try:
+            with self._connect() as smtp:
+                if self.security == 'starttls':
+                    # Upgrade before AUTH: on a plaintext socket the credentials
+                    # would go out in the clear, and most relays refuse AUTH there
+                    # anyway.
+                    smtp.starttls(context=ssl.create_default_context())
+                    smtp.ehlo()
+                if self.username:
+                    smtp.login(self.username, self.password)
+                smtp.send_message(message)
+        except (smtplib.SMTPException, OSError) as exc:
+            # No message, no body, no recipient list beyond the header we already
+            # log — just the fault. ssl.SSLError and socket.timeout are OSError
+            # subclasses, so both arrive here.
+            raise MailError(f"SMTP delivery failed via {self.host}:{self.port}: {exc}") from exc
+        logger.info("Sent mail to %s (subject: %s)", message.get('To', ''), message.get('Subject', ''))
+
+    def _connect(self):
+        """Return a connected SMTP object for the configured security mode."""
+        if self.security == 'ssl':
+            # Implicit TLS (port 465): the socket is encrypted from the first byte,
+            # so there is no plaintext window and no STARTTLS to strip.
+            return smtplib.SMTP_SSL(self.host, self.port, timeout=self.timeout,
+                                    context=ssl.create_default_context())
+        return smtplib.SMTP(self.host, self.port, timeout=self.timeout)
+
+
+class ConsoleMailer(Mailer):
+    """Writes the whole message to the log. The default when no relay is configured.
+
+    A dev checkout has to be able to complete an invite flow, and the invite is
+    only completable if the link is reachable — so this backend deliberately does
+    what the rest of the module forbids and renders the body, token and all. That
+    is sound precisely because it is unreachable in any deployment that sends
+    mail: :func:`build_mailer` only selects it when ``SMTP_HOST`` is unset, which
+    on a real install means invites are not being emailed at all.
+    """
+
+    def send(self, message: EmailMessage) -> None:
+        """Render the message to the log so a developer can read it and click the link."""
+        logger.warning(
+            "ConsoleMailer: no SMTP_HOST configured, mail is being printed rather than sent.\n"
+            "%s", message.as_string()
+        )
+
+
+class NullMailer(Mailer):
+    """Discards everything. Selected by ``MAIL_ENABLED=false``.
+
+    For an operator who wants invites (issued, with the admin copy-link fallback)
+    but no outbound mail at all — and for the console-noise-free case where
+    ConsoleMailer's full dump would be worse than silence.
+    """
+
+    def send(self, message: EmailMessage) -> None:
+        """Drop the message, recording only who it would have gone to."""
+        logger.info("Mail disabled (MAIL_ENABLED=false); dropped message to %s",
+                    message.get('To', ''))
+
+
+class MemoryMailer(Mailer):
+    """Keeps every message in :attr:`outbox`. The test fixture.
+
+    Swapped into ``app.extensions['mailer']`` so a test can assert on what would
+    have been sent without a relay, a socket, or a monkeypatched module global.
+    """
+
+    def __init__(self):
+        self.outbox: list[EmailMessage] = []
+
+    def send(self, message: EmailMessage) -> None:
+        """Append the message to :attr:`outbox`."""
+        self.outbox.append(message)
+
+
+def build_mailer() -> Mailer:
+    """Choose a backend from configuration.
+
+    The order matters, and it is *disabled first*: ``MAIL_ENABLED=false`` is an
+    explicit instruction to send nothing, so it must win even on a host that still
+    has SMTP credentials sitting in its ``.env``.
+
+    1. ``MAIL_ENABLED=false``  -> :class:`NullMailer`
+    2. ``SMTP_HOST`` set       -> :class:`SMTPMailer`
+    3. otherwise               -> :class:`ConsoleMailer`
+    """
+    if not MAIL_ENABLED:
+        return NullMailer()
+    if SMTP_HOST:
+        return SMTPMailer(
+            SMTP_HOST,
+            port=SMTP_PORT,
+            username=SMTP_USERNAME,
+            password=SMTP_PASSWORD,
+            security=SMTP_SECURITY,
+            timeout=MAIL_TIMEOUT_SECONDS,
+        )
+    return ConsoleMailer()

--- a/src/pixelvault/models.py
+++ b/src/pixelvault/models.py
@@ -1,5 +1,6 @@
 import uuid
 from datetime import datetime, timedelta
+from enum import Enum
 from pathlib import Path
 
 from flask_login import UserMixin
@@ -37,12 +38,120 @@ class User(UserMixin, Base):
         """Return True if the given plaintext password matches the stored hash."""
         return check_password_hash(self.password_hash, password)
 
+class InviteState(str, Enum):
+    """The state of one invite, as shown in the admin panel.
+
+    A ``str`` enum so a template can compare against the plain value and a
+    member renders as itself without a ``.value`` everywhere.
+    """
+    ACCEPTED = 'accepted'      # account created; terminal
+    # Not a cosmetic state. Every allowed_email row that predates this feature has
+    # no token, and once registration is link-only those addresses are silently
+    # unusable — the person was told they could sign up and now cannot, with
+    # nothing in the UI to say why. LEGACY is what lets the admin panel list them
+    # as "No invite sent" beside a Send invite button, and it is deliberately
+    # resolved by an admin's click rather than by a migration that emails a
+    # year-old address on deploy day (design §11 Q9).
+    LEGACY = 'legacy'          # whitelist row from before invites existed; no token
+    EXPIRED = 'expired'        # token minted but the TTL ran out unclicked
+    SEND_FAILED = 'send_failed'  # token is live; the relay refused the message
+    ISSUED = 'issued'          # token minted, never emailed (copy-link path)
+    SENT = 'sent'              # emailed, awaiting the click
+
+
 class AllowedEmail(Base):
+    """An authorized email address and the invite issued against it.
+
+    One row is both halves of the fact: the whitelist entry that permits
+    registration, and the credential that carries it to a person. They are kept
+    together because in this app neither exists without the other — see
+    docs/invite_registration_design.md §4.
+
+    The token itself is never stored. ``token_hash`` holds the SHA-256 of it, so
+    a leaked backup or a screenshot of the admin page cannot be used to create an
+    account; the plaintext exists only in the sent email and, for the copy-link
+    fallback, in a single flash message. A resend therefore cannot re-show the
+    old link and mints a new one instead, which also revokes the old.
+
+    Lifecycle position is read from :attr:`state`, derived on every access rather
+    than stored — see that property for why.
+    """
     __tablename__ = 'allowed_email'
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     email: Mapped[str] = mapped_column(String(120), unique=True, nullable=False)
     note: Mapped[str] = mapped_column(String(256), default='')
     added_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    # Indexed because acceptance looks a row up by this and nothing else; an
+    # unindexed scan would also leak, through timing, how far down the table a
+    # guessed token sits.
+    token_hash: Mapped[str] = mapped_column(String(64), nullable=True, index=True)
+    token_issued_at: Mapped[datetime] = mapped_column(DateTime, nullable=True)
+    # Denormalised from token_issued_at + the TTL so the admin table can sort and
+    # display honest expiry without every render re-deriving it against a config
+    # value that may have changed since the token was minted.
+    expires_at: Mapped[datetime] = mapped_column(DateTime, nullable=True)
+    prefill_username: Mapped[str] = mapped_column(String(64), default='')
+    last_sent_at: Mapped[datetime] = mapped_column(DateTime, nullable=True)
+    send_count: Mapped[int] = mapped_column(Integer, default=0)
+    # Truncated to fit, and never carries the token: an SMTP failure string is
+    # rendered back to the admin and may reach a log. Empty means the last send
+    # succeeded.
+    last_send_error: Mapped[str] = mapped_column(String(256), default='')
+    accepted_at: Mapped[datetime] = mapped_column(DateTime, nullable=True)
+    accepted_user_id: Mapped[int] = mapped_column(Integer, ForeignKey('user.id'), nullable=True)
+    invited_by_id: Mapped[int] = mapped_column(Integer, ForeignKey('user.id'), nullable=True)
+
+    @property
+    def state(self) -> InviteState:
+        """Return where this invite stands, derived fresh on every read.
+
+        Deliberately not a stored column: the EXPIRED branch depends on the
+        wall clock, so a persisted value would be wrong from the moment a TTL
+        elapses with nobody looking, and would need a sweep job to stay honest.
+        Deriving it costs one comparison.
+
+        The branch order is the specification (design §4), not an accident —
+        each test precedes the next because it describes a *stronger* fact
+        about the row:
+
+        * ACCEPTED first because it is terminal. The row keeps its old
+          ``expires_at``, so a TTL that lapsed after the account was created
+          would otherwise re-report a live account's invite as EXPIRED.
+        * LEGACY next because a row with no token has nothing the remaining
+          branches can meaningfully test — no expiry, no send history. It is
+          also the only state an admin resolves by *issuing* rather than
+          resending.
+        * EXPIRED above SEND_FAILED because a dead token is the binding
+          problem: re-attempting delivery of a link that no longer works helps
+          nobody, and both faults are fixed by the same rotate-and-resend.
+        * SEND_FAILED above the two success states because the token is fine
+          and only delivery failed — it is a *pending* invite (see
+          :attr:`is_pending`) that happens to need another attempt, which is
+          exactly why it does not outrank EXPIRED.
+        * ISSUED before SENT distinguishes "minted but never emailed" — the
+          copy-link path, and an invite that is issued with mail disabled —
+          from one the relay has accepted.
+        """
+        if self.accepted_at is not None:
+            return InviteState.ACCEPTED
+        if self.token_hash is None:
+            return InviteState.LEGACY
+        if self.expires_at is not None and datetime.utcnow() >= self.expires_at:
+            return InviteState.EXPIRED
+        if self.last_send_error:
+            return InviteState.SEND_FAILED
+        if self.last_sent_at is None:
+            return InviteState.ISSUED
+        return InviteState.SENT
+
+    @property
+    def is_pending(self) -> bool:
+        """Return True while a usable token is outstanding and nobody has accepted it.
+
+        The three states that share one property: the link works today, so the
+        admin's action is to wait or resend, not to issue anew.
+        """
+        return self.state in (InviteState.ISSUED, InviteState.SENT, InviteState.SEND_FAILED)
 
 class Album(Base):
     __tablename__ = "album"

--- a/src/pixelvault/routes/admin.py
+++ b/src/pixelvault/routes/admin.py
@@ -1,9 +1,76 @@
-from flask import render_template, request, redirect, url_for, flash, abort
-from flask_login import login_required
+"""Admin panel routes — the whitelist, which is now the invite desk.
 
-from ..extensions import db, limiter
+Adding an address used to be a one-line insert into a passive whitelist. It is now
+the act that mints a bearer credential and mails it to a stranger, so the four
+routes below are the HTTP layer over ``invites.py`` (lifecycle) and ``emails.py``
+(delivery) in the same way ``routes/share.py`` is a layer over ``uploads.py``:
+they parse a form, choose wording, and own nothing else.
+
+Two sequences in here are contracts rather than preferences, both from
+docs/invite_registration_design.md §13:
+
+* **Issue, commit, then send.** ``invites.issue`` commits before anything is
+  emailed, so a relay outage cannot throw away a valid invite (§7.1). Every send
+  failure is therefore recoverable by *Resend* or the copy-link fallback (§7.3),
+  which is why the failure flash names that fallback instead of apologising.
+* **Renewal always goes through ``invites.rotate``**, never ``issue``. Resend,
+  copy-link, and *Send invite* on a LEGACY row are the same operation with
+  different wording. ``mark_sent`` is deliberately never called from here —
+  ``emails.send_invite`` owns it on both outcomes, and a second call would
+  double-count ``send_count``.
+"""
+
+from flask import render_template, request, redirect, url_for, flash, abort
+from flask_login import login_required, current_user
+
+from .. import emails, invites
+from ..config import PUBLIC_BASE_URL, RE_EMAIL
+from ..extensions import db, limiter, mailer
+from ..mailer import MailError
 from ..models import AllowedEmail, User, Album
 from ..utils import admin_required, delete_photo_files
+
+
+#: Longest address the ``allowed_email.email`` column can hold. Checked here as
+#: well as by RE_EMAIL because SQLite does not enforce VARCHAR length: an
+#: over-long address would store fine now and fail on any other backend later.
+MAX_EMAIL_LEN = 120
+
+
+def _invite_url(token):
+    """Return the acceptance URL for a plaintext token, or ``None`` if it cannot be built.
+
+    Built from ``PUBLIC_BASE_URL`` and ``emails.INVITE_PATH`` — the same two pieces
+    ``emails.build_invite_email`` uses, and deliberately **not** from
+    ``url_for(_external=True)``. Behind Cloudflare -> nginx -> Gunicorn the origin
+    Flask reconstructs comes from forwarded headers, so a spoofed ``Host`` on the
+    admin request would put an attacker's domain in front of a real invite token
+    (design §6). A configured origin has no such input.
+
+    ``None`` rather than a relative URL when the origin is unset: half a link that
+    an admin pastes into a chat window is worse than a refusal, because it fails
+    in the invitee's hands instead of the admin's.
+    """
+    if not PUBLIC_BASE_URL:
+        return None
+    return f"{PUBLIC_BASE_URL.rstrip('/')}{emails.INVITE_PATH}/{token}"
+
+
+def _flash_link(entry, token):
+    """Flash the one and only rendering of ``token`` as a copyable invite URL.
+
+    The plaintext exists exactly once (only its SHA-256 is stored), so this
+    message is the whole artifact — closing the page loses it and the fix is
+    another rotation. The wording says so, because an admin who assumes they can
+    come back for it later hands out a link they no longer have.
+    """
+    url = _invite_url(token)
+    if url is None:
+        flash('PUBLIC_BASE_URL is not configured, so an invite link has no origin. '
+              'Set it and try again — see docs/configuration.md.', 'error')
+        return
+    flash(f'Invite link for {entry.email} — copy it now, it cannot be shown again: {url}',
+          'success')
 
 
 def register(app):
@@ -12,7 +79,7 @@ def register(app):
     @login_required
     @admin_required
     def admin_panel():
-        """Render the admin dashboard showing all allowed emails, registered users, and all albums."""
+        """Render the admin dashboard showing all invites, registered users, and all albums."""
         allowed_emails = db.session.query(AllowedEmail).order_by(AllowedEmail.added_at.desc()).all()
         users = db.session.query(User).order_by(User.created_at.desc()).all()
         albums = db.session.query(Album).order_by(Album.created_at.desc()).all()
@@ -27,22 +94,170 @@ def register(app):
     @admin_required
     @limiter.limit("60 per hour")
     def admin_add_email():
-        """Add an email address to the registration whitelist so the user can create an account."""
+        """Authorize an address, mint its first invite, and email the link (design §7.1).
+
+        The two "already known" branches are separated on purpose. An address that
+        already has an account needs nothing at all; an address that already has an
+        invite needs *Resend*, and saying so is the difference between a dead end
+        and an instruction. The old route answered both with the same shrug.
+
+        Validation uses ``RE_EMAIL``, the same pattern registration enforces. The
+        old ``'@' in email`` check was weaker than the form the address would later
+        have to satisfy, so a typo that passed here produced an invite that could
+        never be accepted — and, now, an email sent into the void.
+        """
         email = request.form.get('email', '').strip().lower()
         note = request.form.get('note', '').strip()
+        # Optional, and only ever a *suggestion*: the invitee may change it. There
+        # is deliberately no is_admin flag beside it (design §11 Q8) — a mistyped
+        # checkbox on this form must never be able to mint an administrator.
+        prefill_username = request.form.get('prefill_username', '').strip()
 
-        if not email or '@' not in email:
+        if not email or not RE_EMAIL.match(email) or len(email) > MAX_EMAIL_LEN:
             flash('Please enter a valid email address.', 'error')
             return redirect(url_for('admin_panel'))
 
-        if db.session.query(AllowedEmail).filter_by(email=email).first():
-            flash(f'{email} is already on the allowed list.', 'info')
+        if db.session.query(User).filter_by(email=email).first():
+            flash(f'{email} already has an account, so there is nothing to invite.', 'info')
             return redirect(url_for('admin_panel'))
 
-        entry = AllowedEmail(email=email, note=note)
-        db.session.add(entry)
-        db.session.commit()
-        flash(f'{email} has been authorized.', 'success')
+        if db.session.query(AllowedEmail).filter_by(email=email).first():
+            flash(f'{email} has already been invited. Use Resend on their row to send '
+                  'a fresh link.', 'info')
+            return redirect(url_for('admin_panel'))
+
+        try:
+            # Commits the row and hands back the plaintext token once. Anything
+            # that goes wrong after this point leaves a resendable invite behind
+            # rather than nothing.
+            invite, token = invites.issue(
+                db.session, email, note=note, prefill_username=prefill_username,
+                invited_by_id=current_user.id,
+            )
+        except invites.InviteError as exc:
+            # Backstop for two admins adding one address in the same second; the
+            # duplicate check above catches every non-racing case.
+            flash(str(exc), 'error')
+            return redirect(url_for('admin_panel'))
+
+        try:
+            emails.send_invite(mailer, db.session, invite, token)
+        except MailError as exc:
+            # The invite is already committed and its token is live, so this is a
+            # delivery problem, not an invite problem. send_invite has recorded the
+            # error on the row (it reads SEND_FAILED in the panel); all that is left
+            # is to point at the fallback that does not need a relay.
+            flash(f'{email} was invited, but the email could not be sent: {exc} '
+                  'Use "Copy link" on their row to hand the link over directly.', 'error')
+        except ValueError as exc:
+            # build_invite_email refuses to compose a link with no origin. Reachable
+            # on a host with mail enabled but PUBLIC_BASE_URL unset — a boot check
+            # covers the SMTP case, but ConsoleMailer and NullMailer boot without it.
+            # Nothing was sent, so the row stays ISSUED and Copy link still works
+            # once the origin is configured.
+            flash(f'{email} was invited, but no email could be composed: {exc}', 'error')
+        else:
+            flash(f'{email} has been invited — an invitation is on its way.', 'success')
+
+        return redirect(url_for('admin_panel'))
+
+    @app.route('/admin/invite/<int:entry_id>/resend', methods=['POST'])
+    @login_required
+    @admin_required
+    @limiter.limit("30 per hour")
+    def admin_resend_invite(entry_id):
+        """Mint a fresh token for an existing invite and email it again (design §7.4).
+
+        Serves four rows with one code path: SENT (never clicked), EXPIRED,
+        SEND_FAILED, and LEGACY — a whitelist entry from before invites existed,
+        which has no token at all. ``rotate`` covers all four because it is the only
+        renewal path there is (design §13); there is deliberately no "issue onto an
+        existing row" variant to get out of step with it.
+
+        The old link dies here. That is a consequence of storing only the hash — it
+        cannot be re-shown, so renewal must mint — and the safer default anyway: a
+        resend usually means the first link was lost or went somewhere it should
+        not have.
+
+        The cooldown is checked *before* rotating, so a refusal costs the invitee
+        nothing: the link they already hold keeps working.
+        """
+        entry = db.session.get(AllowedEmail, entry_id)
+        if not entry:
+            abort(404)
+
+        try:
+            invites.check_resend_allowed(entry)
+        except invites.ResendTooSoon as exc:
+            # Naming the wait is the whole point: "try again later" sends the admin
+            # back to a button that will refuse again with no idea when it will not.
+            flash(f'An invitation to {entry.email} was just sent. Wait '
+                  f'{exc.seconds_remaining} more seconds before sending another.', 'error')
+            return redirect(url_for('admin_panel'))
+
+        try:
+            token = invites.rotate(db.session, entry)
+        except invites.AlreadyAccepted:
+            flash(f'{entry.email} has already registered, so there is nothing to resend.',
+                  'info')
+            return redirect(url_for('admin_panel'))
+
+        try:
+            # send_invite calls mark_sent on both outcomes — success clears any
+            # earlier error, failure records the new one. Calling it here as well
+            # would count one attempt twice.
+            emails.send_invite(mailer, db.session, entry, token)
+        except MailError as exc:
+            flash(f'The invitation to {entry.email} could not be sent: {exc} '
+                  'Use "Copy link" on their row to hand the link over directly.', 'error')
+        except ValueError as exc:
+            flash(f'No invitation to {entry.email} could be composed: {exc}', 'error')
+        else:
+            flash(f'Invitation resent to {entry.email}. Any earlier link has stopped working.',
+                  'success')
+
+        return redirect(url_for('admin_panel'))
+
+    @app.route('/admin/invite/<int:entry_id>/link', methods=['POST'])
+    @login_required
+    @admin_required
+    @limiter.limit("30 per hour")
+    def admin_invite_link(entry_id):
+        """Rotate the invite and show its link once, without sending mail (design §7.3).
+
+        The fallback that makes SMTP optional rather than a hard dependency of
+        registration: a relay that is down, misconfigured, or deliberately absent
+        on a self-hosted box, or an invite sitting in someone's spam folder. The
+        admin gets the URL and hands it over however they like.
+
+        No cooldown check, unlike *Resend*. The cooldown exists because a resend
+        button that mails a third party on demand is a mail-bomb primitive
+        (design §7.4); this route sends nothing, and gating it would disable the
+        fallback in precisely the minute after a failed send — the moment it is
+        most needed. The 30/hour limit still bounds it.
+
+        The origin is checked before rotating so a misconfigured host cannot kill a
+        working link and give nothing back for it.
+        """
+        entry = db.session.get(AllowedEmail, entry_id)
+        if not entry:
+            abort(404)
+
+        if not PUBLIC_BASE_URL:
+            flash('PUBLIC_BASE_URL is not configured, so an invite link has no origin. '
+                  'Set it and try again — see docs/configuration.md.', 'error')
+            return redirect(url_for('admin_panel'))
+
+        try:
+            token = invites.rotate(db.session, entry)
+        except invites.AlreadyAccepted:
+            flash(f'{entry.email} has already registered, so there is no link to give out.',
+                  'info')
+            return redirect(url_for('admin_panel'))
+
+        # No mark_sent: nothing was sent. The row reads ISSUED, which is exactly
+        # "a live token nobody has emailed" — the state this path exists to create.
+        _flash_link(entry, token)
         return redirect(url_for('admin_panel'))
 
     @app.route('/admin/album/<int:album_id>/delete', methods=['POST'])
@@ -65,12 +280,29 @@ def register(app):
     @login_required
     @admin_required
     def admin_remove_email(entry_id):
-        """Remove an email address from the registration whitelist by its database ID."""
+        """Revoke an invite by deleting its row — which also kills its token (design §7.5).
+
+        Revocation needs no separate mechanism: the token hash lives on this row, so
+        deleting it makes any outstanding link unmatchable on the next lookup.
+
+        Deletion does **not** touch the account an accepted invite produced.
+        ``accepted_user_id`` is a plain nullable FK with no relationship or cascade
+        behind it, so the row is bookkeeping about a past event and removing it
+        removes only that. The confirm dialog in admin.html says so, because
+        "remove alice@example.com" reads like an account deletion and an admin who
+        believes that is one click from a surprise.
+        """
         entry = db.session.get(AllowedEmail, entry_id)
         if not entry:
             abort(404)
         email = entry.email
+        was_accepted = entry.accepted_at is not None
         db.session.delete(entry)
         db.session.commit()
-        flash(f'{email} has been removed from the allowed list.', 'info')
+        if was_accepted:
+            flash(f'The invite record for {email} has been removed. Their account is untouched.',
+                  'info')
+        else:
+            flash(f'The invitation for {email} has been revoked; its link no longer works.',
+                  'info')
         return redirect(url_for('admin_panel'))

--- a/src/pixelvault/routes/auth.py
+++ b/src/pixelvault/routes/auth.py
@@ -1,13 +1,124 @@
-from flask import render_template, request, redirect, url_for, flash
+"""Authentication routes — logging in, logging out, and accepting an invitation.
+
+Registration used to be a public form that checked a whitelist at the very end.
+It is now reachable **only** through an invite link, so ``/register`` is gone
+(design §8) and the three routes below replace it:
+
+``GET /invite/<token>``  validate the link, stash it in the session, redirect
+``GET /invite``          render the acceptance form from the stashed token
+``POST /invite``         re-validate, create the account, sign the person in
+
+Two rules in here are load-bearing and easy to erode:
+
+* **The email address comes from the invite row and from nowhere else.** The form
+  shows it read-only and does not even submit it; ``invites.consume`` reads it off
+  the row. Anything else would let the holder of an invite for one address register
+  as another and defeat the whitelist entirely — design §7.2 calls this the single
+  most important line in the feature.
+* **The secret leaves the URL at the first opportunity.** ``/invite/<token>``
+  validates, moves the token into ``session['invite_token']`` and redirects to a
+  path with no secret in it (design §11 Q5). ``Referrer-Policy`` already stops it
+  leaking cross-origin, but a token in the path still lands in nginx access logs
+  and in browser history, which is the other half of what hashing at rest buys.
+
+The GET's verdict is never carried into the POST. An invite can expire, be rotated
+by an admin, or be consumed in another tab between the two requests, and only
+re-validating catches that.
+"""
+
+from flask import render_template, request, redirect, url_for, flash, session
 from flask_login import login_user, logout_user, login_required, current_user
 
+from .. import invites
+from ..config import ADMIN_CONTACT, RE_USERNAME, MAX_PASSWORD_LEN
 from ..extensions import db, limiter
 from ..models import User, AllowedEmail
-from ..config import RE_USERNAME, RE_EMAIL, MAX_PASSWORD_LEN
 from ..utils import is_safe_redirect
 
 
+#: Where the plaintext invite token lives between the click and the form.
+#: Fixed by design §13 alongside the endpoint names — the session cookie is signed,
+#: so this is a server-authenticated copy of the token rather than one the browser
+#: can rewrite, which is precisely why the form carries no hidden token field.
+INVITE_SESSION_KEY = 'invite_token'
+
+#: Username shape, identical to what /register enforced. Kept as constants rather
+#: than inlined so the acceptance form and any future admin-side check cannot drift.
+MIN_USERNAME_LEN = 3
+MAX_USERNAME_LEN = 64
+MIN_PASSWORD_LEN = 8
+
+
+def _refuse(message, status):
+    """Flash ``message`` and answer with the login page under an honest status code.
+
+    The login page rather than a bespoke error template because every one of these
+    refusals ends in the same two pieces of advice — sign in, or ask an admin for a
+    fresh link — and the sign-in half is right there on the page.
+
+    The status is not decoration. These responses are the public face of a bearer
+    credential, and a monitoring or crawling client that sees 200 for a dead link
+    learns the opposite of the truth. Returned as a tuple rather than via ``abort``
+    so the app's generic error page does not swallow the specific advice.
+    """
+    flash(message, 'error')
+    return render_template('login.html'), status
+
+
+def _refuse_invite_error(exc):
+    """Map an :class:`invites.InviteError` onto wording and a status.
+
+    The four faults get four different messages because they need four different
+    actions from the reader, and a single "invalid link" for all of them is what
+    made the old whitelist a dead end.
+
+    ``InvalidInvite`` is deliberately worded for two audiences at once.
+    ``consume`` nulls ``token_hash``, so a link that has already been used is
+    *indistinguishable* from a typo — the row it pointed at no longer matches
+    anything (design §13). Claiming to know which one happened would be a guess,
+    and guessing wrong strands whichever reader we guessed against.
+
+    ``ResendTooSoon`` cannot reach here: it is raised only by the admin panel's
+    resend path, which sends mail. Nothing on this side of the flow sends anything.
+    """
+    if isinstance(exc, invites.AlreadyAccepted):
+        return _refuse(
+            'That invitation has already been accepted and the account exists. '
+            'Sign in below, or use "Forgot your password" with an admin if you '
+            'cannot get in.',
+            409,
+        )
+    if isinstance(exc, invites.ExpiredInvite):
+        return _refuse(
+            'This invitation link has expired. Ask an admin to send you a new one — '
+            'it takes them one click.',
+            410,
+        )
+    if isinstance(exc, invites.InvalidInvite):
+        return _refuse(
+            'This invitation link is not valid. Check that you copied the whole link, '
+            'including the part after the last slash. If you have already used it to '
+            'create your account, sign in below instead — a link stops working the '
+            'moment it is accepted.',
+            404,
+        )
+    # The base InviteError, which validate() never raises today. Kept so a future
+    # subclass surfaces as a refusal rather than a 500.
+    return _refuse(str(exc), 400)
+
+
 def register(app):
+
+    @app.context_processor
+    def inject_admin_contact():
+        """Expose ``ADMIN_CONTACT`` to every template.
+
+        ``request_permission.html`` is rendered from ``routes/albums.py`` and now has
+        to name someone to ask for an invitation (design §8); a context processor is
+        how it gets the address without every render call learning about mail config.
+        Registered here because this module owns the invite-only story.
+        """
+        return {'admin_contact': ADMIN_CONTACT}
 
     @app.route('/')
     def index():
@@ -16,64 +127,148 @@ def register(app):
             return redirect(url_for('dashboard'))
         return redirect(url_for('login'))
 
-    @app.route('/register', methods=['GET', 'POST'])
-    @limiter.limit("10 per hour")
-    def register():
-        """
-        Handle new user registration.
+    # ── Accepting an invitation ────────────────────────────────────────────
 
-        GET  — render the registration form.
-        POST — validate the submitted username, email, and password, then create the account.
-               Registration is invite-only: the email must already exist in AllowedEmail.
+    @app.route('/invite/<token>')
+    @limiter.limit("60 per hour")
+    def invite_link(token):
+        """Validate an invite link, move the token into the session, and redirect.
+
+        The redirect is the point of the route (design §11 Q5). The token is a
+        bearer credential that creates an account bound to someone's real email
+        address, and a URL carrying it is copied into nginx access logs, browser
+        history, and any bookmark or shared "here's the page I'm on" message. One
+        redirect later the address bar holds nothing worth stealing.
+
+        Validation happens **before** the stash so a bad link is answered here, with
+        advice specific to what is wrong with it, instead of being carried forward
+        into a form that fails on submit for reasons the reader cannot see.
         """
         if current_user.is_authenticated:
-            return redirect(url_for('dashboard'))
+            return _refuse_live_session()
 
-        if request.method == 'POST':
-            username = request.form.get('username', '').strip()
-            email = request.form.get('email', '').strip().lower()
-            password = request.form.get('password', '')
-            confirm = request.form.get('confirm_password', '')
+        try:
+            invites.validate(db.session, token)
+        except invites.InviteError as exc:
+            return _refuse_invite_error(exc)
 
-            errors = []
-            if not username or len(username) < 3:
-                errors.append("Username must be at least 3 characters.")
-            elif len(username) > 64:
-                errors.append("Username must be 64 characters or fewer.")
-            elif not RE_USERNAME.match(username):
-                errors.append("Username may only contain letters, numbers, hyphens, and underscores.")
-            if not email or not RE_EMAIL.match(email):
-                errors.append("Please enter a valid email address.")
-            elif len(email) > 120:
-                errors.append("Email address is too long.")
-            if len(password) < 8:
-                errors.append("Password must be at least 8 characters.")
-            elif len(password) > MAX_PASSWORD_LEN:
-                errors.append("Password is too long.")
-            if password != confirm:
-                errors.append("Passwords do not match.")
-            if not errors:
-                if db.session.query(User).filter_by(username=username).first():
-                    errors.append("Username already taken.")
-                if db.session.query(User).filter_by(email=email).first():
-                    errors.append("Email already registered.")
-                if not db.session.query(AllowedEmail).filter_by(email=email).first():
-                    errors.append("This email address has not been authorized to register.")
+        session[INVITE_SESSION_KEY] = token
+        return redirect(url_for('invite_form'))
 
-            if errors:
-                for e in errors:
-                    flash(e, 'error')
-                return render_template('register.html', username=username, email=email)
+    @app.route('/invite')
+    @limiter.limit("60 per hour")
+    def invite_form():
+        """Render the acceptance form for the invite stashed in the session.
 
-            user = User(username=username, email=email)
-            user.set_password(password)
-            db.session.add(user)
-            db.session.commit()
-            login_user(user, remember=True)
-            flash('Welcome to PixelVault!', 'success')
-            return redirect(url_for('dashboard'))
+        Re-validates rather than trusting the stash. The session survives for days;
+        the invite it names may have expired or been rotated by an admin since the
+        click, and finding that out now is better than after a password has been
+        typed twice.
+        """
+        if current_user.is_authenticated:
+            return _refuse_live_session()
 
-        return render_template('register.html')
+        invite, refusal = _stashed_invite()
+        if refusal is not None:
+            return refusal
+
+        return render_template(
+            'register.html',
+            email=invite.email,
+            # A suggestion from the admin, not a decision: the invitee may change it
+            # (design §11 Q8).
+            username=invite.prefill_username or '',
+        )
+
+    @app.route('/invite', methods=['POST'])
+    @limiter.limit("20 per hour")
+    def invite_submit():
+        """Create the account an invitation authorizes and sign the new user in.
+
+        The username and password rules are exactly the ones ``/register`` enforced,
+        down to the wording — this route replaces that one, and quietly relaxing a
+        rule during a move is how a password minimum disappears without anyone
+        deciding to remove it.
+
+        What is *not* taken from the form is the email address. It is read off the
+        invite row inside ``invites.consume`` and the form does not even submit a
+        field for it, so a hand-crafted POST carrying ``email=someone.else@...``
+        changes nothing. That is the whole security property of the feature: the
+        whitelist means nothing if the holder of a link can pick the address it
+        authorizes.
+        """
+        if current_user.is_authenticated:
+            return _refuse_live_session()
+
+        invite, refusal = _stashed_invite()
+        if refusal is not None:
+            return refusal
+
+        username = request.form.get('username', '').strip()
+        password = request.form.get('password', '')
+        confirm = request.form.get('confirm_password', '')
+        # request.form['email'] is deliberately never read. See the docstring.
+
+        errors = []
+        if not username or len(username) < MIN_USERNAME_LEN:
+            errors.append("Username must be at least 3 characters.")
+        elif len(username) > MAX_USERNAME_LEN:
+            errors.append("Username must be 64 characters or fewer.")
+        elif not RE_USERNAME.match(username):
+            errors.append("Username may only contain letters, numbers, hyphens, and underscores.")
+        if len(password) < MIN_PASSWORD_LEN:
+            errors.append("Password must be at least 8 characters.")
+        elif len(password) > MAX_PASSWORD_LEN:
+            # Not a style rule: set_password runs 600k PBKDF2 rounds, so an
+            # unbounded password is a way to spend a worker thread on demand.
+            errors.append("Password is too long.")
+        if password != confirm:
+            errors.append("Passwords do not match.")
+
+        if not errors:
+            if db.session.query(User).filter_by(username=username).first():
+                errors.append("Username already taken.")
+            if db.session.query(User).filter_by(email=invite.email).first():
+                # Reachable when an admin created the account by hand after issuing
+                # the invite. Caught here because consume() would otherwise fail on
+                # the unique index and be reported as a username collision, sending
+                # the reader off to invent names that will never work.
+                errors.append("An account already exists for this address. Please log in instead.")
+            if not db.session.query(AllowedEmail).filter_by(email=invite.email).first():
+                # Belt and braces (design §8). A valid token already implies the
+                # whitelist row, because the token *lives on* that row — but this
+                # assertion is what keeps the whitelist the thing registration is
+                # gated on, rather than a comment claiming it once was.
+                errors.append("This email address has not been authorized to register.")
+
+        if errors:
+            for e in errors:
+                flash(e, 'error')
+            return render_template('register.html', username=username, email=invite.email)
+
+        try:
+            user = invites.consume(db.session, invite, username=username, password=password)
+        except invites.InviteError as exc:
+            if isinstance(exc, (invites.InvalidInvite, invites.ExpiredInvite,
+                                invites.AlreadyAccepted)):
+                # A double-submit or a shared link losing the race between the
+                # check above and the commit. The invite is spent either way, so
+                # the session copy is worthless now.
+                session.pop(INVITE_SESSION_KEY, None)
+                return _refuse_invite_error(exc)
+            # The base InviteError is the username-collision backstop; it is worth
+            # re-showing the form for, because a different name will work.
+            flash(str(exc), 'error')
+            return render_template('register.html', username=username, email=invite.email)
+
+        # The token is spent. Dropping it stops a browser-history "back" from
+        # replaying the form against a row that can only refuse it now.
+        session.pop(INVITE_SESSION_KEY, None)
+        login_user(user, remember=True)
+        flash('Welcome to PixelVault!', 'success')
+        return redirect(url_for('dashboard'))
+
+    # ── Sessions ───────────────────────────────────────────────────────────
 
     @app.route('/login', methods=['GET', 'POST'])
     @limiter.limit("20 per hour")
@@ -115,3 +310,56 @@ def register(app):
         logout_user()
         flash('You have been logged out.', 'info')
         return redirect(url_for('login'))
+
+
+# ── Helpers shared by the three invite routes ──────────────────────────────
+
+def _refuse_live_session():
+    """Refuse to run an invitation into a session that already belongs to someone.
+
+    Design §7.2 allows either logging the visitor out or refusing. **Refusing** is
+    the choice here, for two reasons:
+
+    * Logging them out is a side effect any stranger can trigger in someone else's
+      browser by getting them to open a URL. A drive-by logout that discards an
+      in-progress upload is a worse outcome than a message.
+    * The server cannot tell whether the signed-in person is the invitee. Silently
+      swapping sessions would be guessing about identity at exactly the moment the
+      answer matters, and the person best placed to decide is the one reading the
+      screen.
+
+    The token is not stashed, not validated and not consumed, so the link keeps
+    working for whoever it was actually sent to.
+    """
+    flash('You are already signed in. An invitation creates a new account, so log out '
+          'first if this invitation is for someone else.', 'info')
+    return redirect(url_for('dashboard'))
+
+
+def _stashed_invite():
+    """Return ``(invite, None)`` for a live stashed token, or ``(None, response)``.
+
+    Both halves of the form need the same three-step check — is there a token, is
+    it still good, and if not what should the reader be told — and splitting it
+    would let the GET and the POST answer the same broken link differently.
+
+    A dead token is dropped from the session on the way out. Leaving it there turns
+    every later visit to ``/invite`` into the same refusal with no way to clear it
+    short of the reader knowing to delete a cookie.
+    """
+    token = session.get(INVITE_SESSION_KEY)
+    if not token:
+        # Someone typed /invite, or came back long after their cookie expired.
+        # Worth its own wording: there is nothing wrong with any link, they just
+        # have not opened one.
+        return None, _refuse(
+            'Open the invitation link you were sent to create your account. '
+            'PixelVault is invite-only, so there is no public sign-up page.',
+            403,
+        )
+
+    try:
+        return invites.validate(db.session, token), None
+    except invites.InviteError as exc:
+        session.pop(INVITE_SESSION_KEY, None)
+        return None, _refuse_invite_error(exc)

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -32,9 +32,10 @@
 
   .email-row {
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     justify-content: space-between;
     gap: 0.75rem;
+    flex-wrap: wrap;
     padding: 0.65rem 0.9rem;
     background: var(--bg);
     border: 1px solid var(--border);
@@ -42,6 +43,60 @@
   }
 
   .email-row-info { flex: 1; min-width: 0; }
+
+  /* Two states are problems and read as such; the rest sit on the palette
+     already defined in base.html. */
+  .badge-blue { background: rgba(52, 152, 219, 0.15); color: #70a8e8; }
+  .badge-red  { background: rgba(192, 57, 43, 0.22);  color: #e87070; }
+  .badge-rust { background: rgba(192, 57, 43, 0.12);  color: #c98d84; }
+
+  .email-row-lines {
+    display: flex;
+    flex-direction: column;
+    gap: 0.1rem;
+    margin-top: 0.25rem;
+    font-size: 0.72rem;
+    color: var(--text-muted);
+    font-family: var(--font-mono);
+  }
+
+  .email-row-error {
+    margin-top: 0.25rem;
+    font-size: 0.72rem;
+    color: #e87070;
+    overflow-wrap: anywhere;
+  }
+
+  .email-row-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+    flex-shrink: 0;
+    flex-wrap: wrap;
+  }
+
+  /* The copy-link flash is moved in here on load. Flashes self-destruct after
+     five seconds and this is the single rendering of a token that can never be
+     shown again, so it must not be on that clock. */
+  .invite-link-box {
+    display: none;
+    align-items: center;
+    gap: 0.5rem;
+    margin-top: 1.25rem;
+    padding: 0.65rem 0.9rem;
+    background: var(--bg);
+    border: 1px solid var(--green);
+    border-radius: var(--radius);
+  }
+
+  .invite-link-url {
+    flex: 1;
+    min-width: 0;
+    font-family: var(--font-mono);
+    font-size: 0.75rem;
+    color: var(--text);
+    overflow-wrap: anywhere;
+  }
 
   .email-row-addr {
     font-family: var(--font-mono);
@@ -230,50 +285,126 @@
 {% block content %}
 <div class="page-header">
   <h1>Admin Panel</h1>
-  <p>Manage authorized email addresses and view registered users.</p>
+  <p>Invite new members, track their invitations, and view registered users.</p>
 </div>
 
 <div class="admin-grid">
 
-  <!-- Allowed Emails -->
+  <!-- Invitations -->
   <div>
     <div class="card">
-      <div class="section-title">Authorized Emails</div>
+      <div class="section-title">Invitations</div>
 
       <form method="POST" action="{{ url_for('admin_add_email') }}" class="add-form">
         <div class="form-group" style="margin-bottom:0;">
-          <label for="new-email">Add Email Address</label>
+          <label for="new-email">Invite Email Address</label>
           <div class="add-form-row">
             <input type="email" id="new-email" name="email" placeholder="user@example.com" required>
-            <button type="submit" class="btn btn-primary">Add</button>
+            <button type="submit" class="btn btn-primary">Invite</button>
           </div>
         </div>
         <div class="form-group" style="margin-bottom:0;">
-          <label for="new-note">Note (optional)</label>
+          <label for="new-note">Note (optional, admin-only)</label>
           <input type="text" id="new-note" name="note" placeholder="e.g. Alice's account" maxlength="256">
         </div>
+        <div class="form-group" style="margin-bottom:0;">
+          <label for="new-username">Suggested username (optional)</label>
+          <input type="text" id="new-username" name="prefill_username" placeholder="e.g. alice" maxlength="64">
+        </div>
       </form>
+
+      <!-- Populated on load from the copy-link flash; see the script block. -->
+      <div class="invite-link-box" id="invite-link-box">
+        <span class="invite-link-url" id="invite-link-url"></span>
+        <button type="button" class="btn btn-ghost btn-sm" id="invite-link-copy">Copy</button>
+      </div>
+
+      {#- One badge class and one label per InviteState. Kept as maps rather than an
+          if-chain so a seventh state added to the model shows up as a KeyError here
+          instead of silently rendering as a blank row. -#}
+      {% set state_badge = {
+           'accepted':    'badge-green',
+           'sent':        'badge-blue',
+           'issued':      'badge-dim',
+           'legacy':      'badge-amber',
+           'expired':     'badge-rust',
+           'send_failed': 'badge-red',
+         } %}
+      {% set state_label = {
+           'accepted':    'accepted',
+           'sent':        'sent',
+           'issued':      'not emailed',
+           'legacy':      'no invite',
+           'expired':     'expired',
+           'send_failed': 'send failed',
+         } %}
 
       <div class="email-list">
         {% if allowed_emails %}
           {% for entry in allowed_emails %}
+          {#- .value, not the member: InviteState is a str Enum whose repr would
+              render as "InviteState.SENT" in a template. -#}
+          {% set state = entry.state.value %}
           <div class="email-row">
             <div class="email-row-info">
-              <div class="email-row-addr">{{ entry.email }}</div>
+              <div class="email-row-addr">
+                {{ entry.email }}
+                <span class="badge {{ state_badge[state] }}">{{ state_label[state] }}</span>
+              </div>
               {% if entry.note %}
                 <div class="email-row-note">{{ entry.note }}</div>
               {% endif %}
+              {% if entry.prefill_username %}
+                <div class="email-row-note">Suggested username: {{ entry.prefill_username }}</div>
+              {% endif %}
+              <div class="email-row-lines">
+                {% if state == 'accepted' %}
+                  <span>Accepted {{ entry.accepted_at.strftime('%b %d, %Y') }}</span>
+                {% elif state == 'legacy' %}
+                  <span>Added {{ entry.added_at.strftime('%b %d, %Y') }} — predates invites</span>
+                {% else %}
+                  {% if entry.last_sent_at %}
+                    <span>Sent {{ entry.last_sent_at.strftime('%b %d, %Y %H:%M') }} UTC{% if entry.send_count and entry.send_count > 1 %} · {{ entry.send_count }} attempts{% endif %}</span>
+                  {% else %}
+                    <span>Never emailed — hand the link over with Copy link</span>
+                  {% endif %}
+                  {% if entry.expires_at %}
+                    <span>{{ 'Expired' if state == 'expired' else 'Expires' }} {{ entry.expires_at.strftime('%b %d, %Y %H:%M') }} UTC</span>
+                  {% endif %}
+                {% endif %}
+              </div>
+              {#- A string from a remote relay. Autoescaped like everything else,
+                  and truncated because a bounce message can run to paragraphs. -#}
+              {% if entry.last_send_error %}
+                <div class="email-row-error" title="{{ entry.last_send_error }}">
+                  Delivery failed: {{ entry.last_send_error | truncate(120, True) }}
+                </div>
+              {% endif %}
             </div>
-            <div class="email-row-meta">{{ entry.added_at.strftime('%b %d, %Y') }}</div>
-            <form method="POST" action="{{ url_for('admin_remove_email', entry_id=entry.id) }}"
-                  onsubmit="return confirm('Remove {{ entry.email }} from allowed list?')">
-              <button type="submit" class="btn btn-danger btn-sm">Remove</button>
-            </form>
+            <div class="email-row-actions">
+              {% if state != 'accepted' %}
+                {#- One route, two labels: a LEGACY row (and any invite that was
+                    never emailed) has nothing to *re*-send. -#}
+                <form method="POST" action="{{ url_for('admin_resend_invite', entry_id=entry.id) }}">
+                  <button type="submit" class="btn btn-ghost btn-sm">
+                    {{ 'Resend' if entry.last_sent_at else 'Send invite' }}
+                  </button>
+                </form>
+                <form method="POST" action="{{ url_for('admin_invite_link', entry_id=entry.id) }}"
+                      onsubmit="return confirm('Generate a new invite link for {{ entry.email }}? Any link already sent stops working immediately, and the new one is shown only once.')">
+                  <button type="submit" class="btn btn-ghost btn-sm">Copy link</button>
+                </form>
+              {% endif %}
+              <form method="POST" action="{{ url_for('admin_remove_email', entry_id=entry.id) }}"
+                    onsubmit="return confirm({% if state == 'accepted' %}'Remove the invite record for {{ entry.email }}? Their account, albums and photos are not touched — only this record goes.'{% else %}'Revoke the invitation for {{ entry.email }}? Any link already sent stops working immediately and they will no longer be able to register.'{% endif %})">
+                <button type="submit" class="btn btn-danger btn-sm">Remove</button>
+              </form>
+            </div>
           </div>
           {% endfor %}
         {% else %}
           <div class="empty-state" style="padding:2rem 0;">
-            <p>No emails authorized yet. Add one above.</p>
+            <p>Nobody has been invited yet. Invite someone above.</p>
           </div>
         {% endif %}
       </div>
@@ -411,6 +542,55 @@
 
 {% block scripts %}
 <script>
+  // The copy-link flash carries the only rendering of an invite token there will
+  // ever be — the server stores just its SHA-256, so a lost link costs another
+  // rotation and breaks the one already sent. base.html removes every flash after
+  // five seconds, which is fine for "album deleted" and wrong for this, so the URL
+  // is lifted into a box on the page that stays put.
+  document.addEventListener('DOMContentLoaded', () => {
+    const box = document.getElementById('invite-link-box');
+    if (!box) return;
+    document.querySelectorAll('.flashes .flash').forEach(flash => {
+      const text = flash.textContent || '';
+      const match = text.match(/https?:\/\/\S+\/invite\/\S+/);
+      if (!match) return;
+      const url = match[0];
+      // textContent, never innerHTML: the URL came back from the server as text
+      // and must not be re-parsed as markup on the way into the DOM.
+      document.getElementById('invite-link-url').textContent = url;
+      box.style.display = 'flex';
+      document.getElementById('invite-link-copy').onclick = () => copyInviteLink(url);
+      flash.remove();
+    });
+  });
+
+  function copyInviteLink(url) {
+    const button = document.getElementById('invite-link-copy');
+    function onSuccess() {
+      button.textContent = 'Copied';
+      setTimeout(() => { button.textContent = 'Copy'; }, 2000);
+    }
+    if (navigator.clipboard) {
+      navigator.clipboard.writeText(url).then(onSuccess).catch(() => fallbackCopy(url, onSuccess));
+    } else {
+      fallbackCopy(url, onSuccess);
+    }
+  }
+
+  // navigator.clipboard is unavailable on plain HTTP, which a self-hosted install
+  // behind no TLS terminator genuinely is; the textarea trick is the only path
+  // there. Same shape as dashboard.html's.
+  function fallbackCopy(text, onSuccess) {
+    const ta = document.createElement('textarea');
+    ta.value = text;
+    ta.style.cssText = 'position:fixed;opacity:0;pointer-events:none;';
+    document.body.appendChild(ta);
+    ta.focus();
+    ta.select();
+    try { document.execCommand('copy'); onSuccess(); } catch (_) {}
+    document.body.removeChild(ta);
+  }
+
   function filterUsers() {
     const name = document.getElementById('user-filter-name').value.toLowerCase().trim();
     const email = document.getElementById('user-filter-email').value.toLowerCase().trim();

--- a/templates/base.html
+++ b/templates/base.html
@@ -421,8 +421,10 @@
         </div>
       </div>
     {% else %}
-      <a href="{{ url_for('login') }}">Log in</a>
-      <a href="{{ url_for('register') }}" class="btn-primary btn btn-sm">Sign up</a>
+      {# No "Sign up" button: registration is invite-only and /register no longer
+         exists, so url_for('register') here would raise BuildError on every page an
+         anonymous visitor can reach — including the invite acceptance form itself. #}
+      <a href="{{ url_for('login') }}" class="btn-primary btn btn-sm">Log in</a>
     {% endif %}
   </div>
 </nav>

--- a/templates/email/invite.html
+++ b/templates/email/invite.html
@@ -1,0 +1,116 @@
+{# HTML part of the invite email — the garnish, never the payload.
+
+   Written for mail clients, not browsers, which is why it looks nothing like the
+   rest of templates/:
+
+   * Tables for layout. Outlook renders through Word, which has no float, no
+     flex and no grid.
+   * Every style inline. Gmail strips <style> blocks in several of its clients,
+     so a rule that lives in a <head> is a rule that may not exist.
+   * No images, no web fonts, no external anything. Remote assets are blocked by
+     default in most clients and by every privacy-minded one, and Cormorant
+     Garamond — the product's serif — cannot be loaded here, so the wordmark
+     falls back to Georgia, which is already the next entry in the app's own
+     font stack.
+   * No JavaScript, which no client will run.
+
+   The design goal is that this degrades to the text part rather than away from
+   it: strip every attribute below and what remains is the same sentences in the
+   same order, with the invite URL visible in full as text. The button is a
+   convenience; the plain URL underneath it is the guarantee, because some
+   clients and gateways rewrite or break anchors.
+
+   Autoescaped (Jinja escapes .html), so the address and URL below are safe to
+   interpolate. Keep the palette in step with templates/base.html: #0d0d0f page,
+   #141417 card, #2a2a30 border, #e8e6e0 text, #888680 dim, #d4a853 amber. #}
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#0d0d0f" style="background-color:#0d0d0f;margin:0;padding:0;width:100%;">
+  <tr>
+    <td align="center" style="padding:32px 12px;">
+
+      <table role="presentation" width="560" cellpadding="0" cellspacing="0" border="0" bgcolor="#141417" style="background-color:#141417;border:1px solid #2a2a30;border-radius:6px;max-width:560px;width:100%;">
+        <tr>
+          <td style="padding:36px 36px 8px 36px;font-family:Georgia,'Times New Roman',serif;font-size:28px;line-height:1.2;color:#e8e6e0;">
+            PixelVault<span style="color:#d4a853;">.</span>
+          </td>
+        </tr>
+        <tr>
+          <td style="padding:0 36px 24px 36px;font-family:Georgia,'Times New Roman',serif;font-size:19px;line-height:1.4;color:#888680;border-bottom:1px solid #2a2a30;">
+            You have been invited
+          </td>
+        </tr>
+
+        <tr>
+          <td style="padding:28px 36px 0 36px;font-family:Helvetica,Arial,sans-serif;font-size:15px;line-height:1.6;color:#e8e6e0;">
+            <p style="margin:0 0 16px 0;">Hello,</p>
+            <p style="margin:0 0 16px 0;">
+              Someone has invited you to PixelVault, a private photo album site at
+              <a href="{{ site_url }}" style="color:#d4a853;text-decoration:none;">{{ site_url }}</a>.
+              To accept, open the link below and choose a username and a password.
+            </p>
+          </td>
+        </tr>
+
+        <tr>
+          <td align="left" style="padding:12px 36px 20px 36px;">
+            {# Bulletproof button: colour on the <td>, padding on the <a>. A
+               background set on the anchor alone disappears in Outlook. #}
+            <table role="presentation" cellpadding="0" cellspacing="0" border="0">
+              <tr>
+                <td bgcolor="#d4a853" style="background-color:#d4a853;border-radius:6px;">
+                  <a href="{{ invite_url }}" style="display:inline-block;padding:14px 30px;font-family:Helvetica,Arial,sans-serif;font-size:15px;font-weight:bold;color:#0d0d0f;text-decoration:none;">Create your account</a>
+                </td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+
+        <tr>
+          <td style="padding:0 36px 4px 36px;font-family:Helvetica,Arial,sans-serif;font-size:13px;line-height:1.5;color:#888680;">
+            Or paste this address into your browser:
+          </td>
+        </tr>
+        <tr>
+          <td style="padding:0 36px 24px 36px;font-family:'Courier New',Courier,monospace;font-size:13px;line-height:1.5;word-break:break-all;">
+            <a href="{{ invite_url }}" style="color:#d4a853;text-decoration:underline;word-break:break-all;">{{ invite_url }}</a>
+          </td>
+        </tr>
+
+        <tr>
+          <td style="padding:24px 36px;font-family:Helvetica,Arial,sans-serif;font-size:14px;line-height:1.6;color:#e8e6e0;border-top:1px solid #2a2a30;">
+            <p style="margin:0 0 12px 0;">
+              The link stops working on <strong style="color:#e8e6e0;">{{ expires_at_text }}</strong>{% if expires_in_text %}, {{ expires_in_text }} from now{% endif %}.
+              After that you will need to ask for a new one.
+            </p>
+            <p style="margin:0 0 12px 0;">
+              It can be used once, and it creates an account for
+              <strong style="color:#e8e6e0;">{{ email }}</strong> only &mdash; that address is
+              filled in for you and cannot be changed on the form.
+            </p>
+            {% if username %}
+            <p style="margin:0 0 12px 0;">
+              The username <strong style="color:#e8e6e0;">{{ username }}</strong> has been
+              suggested for you. You can keep it or pick another one.
+            </p>
+            {% endif %}
+          </td>
+        </tr>
+
+        <tr>
+          <td style="padding:0 36px 32px 36px;font-family:Helvetica,Arial,sans-serif;font-size:13px;line-height:1.6;color:#888680;">
+            If you were not expecting this invitation you can ignore this message. The link
+            expires on its own, and no account is created until someone uses it.
+          </td>
+        </tr>
+      </table>
+
+      <table role="presentation" width="560" cellpadding="0" cellspacing="0" border="0" style="max-width:560px;width:100%;">
+        <tr>
+          <td align="center" style="padding:16px 12px 0 12px;font-family:Helvetica,Arial,sans-serif;font-size:12px;line-height:1.5;color:#555450;">
+            PixelVault &mdash; invite-only photo albums
+          </td>
+        </tr>
+      </table>
+
+    </td>
+  </tr>
+</table>

--- a/templates/email/invite.txt
+++ b/templates/email/invite.txt
@@ -1,0 +1,38 @@
+{# Plain-text part of the invite email — the part that always renders.
+
+   This is the copy that has to work everywhere: a text-only client, a screen
+   reader, a spam quarantine digest, a phone showing a preview. The HTML
+   alternative beside it may be stripped or mangled; this one may not be, so the
+   full URL appears here on its own line, unwrapped and unadorned, and every fact
+   the invitee needs is stated in words rather than in layout.
+
+   Not autoescaped — Jinja escapes .html templates only — so keep every value
+   here inside plain prose. Nothing below is HTML, and nothing below may become
+   HTML without moving to the other file.
+-#}
+You have been invited to PixelVault
+===================================
+
+Hello,
+
+Someone has invited you to PixelVault, a private photo album site at
+{{ site_url }}. To accept, open this link and choose a username and a
+password:
+
+{{ invite_url }}
+
+The link stops working on {{ expires_at_text }}{% if expires_in_text %}, {{ expires_in_text }} from now{% endif %}.
+After that you will need to ask for a new one.
+
+It can be used once, and it creates an account for {{ email }} only -- that
+address is filled in for you and cannot be changed on the form.
+{%- if username %}
+
+The username {{ username }} has been suggested for you. You can keep it or pick
+another one.
+{%- endif %}
+
+If you were not expecting this invitation you can ignore this message. The link
+expires on its own, and no account is created until someone uses it.
+
+-- PixelVault

--- a/templates/login.html
+++ b/templates/login.html
@@ -58,7 +58,14 @@
     <div class="auth-logo">PixelVault<span>.</span></div>
     <h2>Welcome back</h2>
 
-    <form method="POST">
+    {#
+      An explicit action, not the empty default. This page is also rendered from
+      /invite and /invite/<token> when a link is refused, so "post to whatever URL
+      you are on" would send the login form to the invite endpoint. `next` is
+      carried through by hand because that action would otherwise drop the query
+      string, sending everyone to the dashboard instead of the album they asked for.
+    #}
+    <form method="POST" action="{{ url_for('login', next=request.args.get('next')) }}">
       <div class="form-group">
         <label for="username">Username</label>
         <input type="text" id="username" name="username" value="{{ username|default('') }}"
@@ -78,8 +85,12 @@
       </button>
     </form>
 
+    {# Invite-only since #7: there is no sign-up page to link to. Saying so plainly
+       beats a missing link, which reads as a broken page and produces the support
+       question this sentence exists to answer. #}
     <div class="auth-footer">
-      Don't have an account? <a href="{{ url_for('register') }}">Sign up</a>
+      PixelVault is invite-only. Ask an admin for an invitation
+      {%- if admin_contact %} at {{ admin_contact }}{% endif %} to create an account.
     </div>
   </div>
 </div>

--- a/templates/register.html
+++ b/templates/register.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}Sign Up — PixelVault{% endblock %}
+{% block title %}Accept Your Invitation — PixelVault{% endblock %}
 
 {% block head %}
 <style>
@@ -55,6 +55,15 @@
     color: var(--text-muted);
     margin-top: 0.3rem;
   }
+
+  /* The locked address. Styled as something settled rather than something the
+     reader failed to fill in — a plain disabled-looking box invites a support
+     question about why they cannot type in it. */
+  .locked-field input {
+    background: var(--bg);
+    color: var(--text-dim);
+    cursor: not-allowed;
+  }
 </style>
 {% endblock %}
 
@@ -62,18 +71,35 @@
 <div class="auth-wrap">
   <div class="auth-card">
     <div class="auth-logo">PixelVault<span>.</span></div>
-    <h2>Create your account</h2>
+    <h2>Accept your invitation</h2>
 
-    <form method="POST">
+    {#
+      The acceptance form. Two things about it are security properties, not layout:
+
+      * The email field has **no `name` attribute**, so the browser posts nothing for
+        it. The address the account is created with is read off the invite row in
+        `invites.consume`; a posted one is ignored even if a hand-crafted request
+        carries it. Giving the field a name would put an attacker-supplied copy of
+        the most important value in the flow one careless `request.form` away.
+      * There is no hidden token field either. The token lives in the signed session
+        (`session['invite_token']`), which the browser cannot rewrite, and keeping it
+        out of the markup keeps it out of page caches and "view source".
+    #}
+    <form method="POST" action="{{ url_for('invite_submit') }}">
+      <div class="form-group locked-field">
+        <label for="email">Email</label>
+        <input type="email" id="email" value="{{ email|default('') }}" readonly
+               tabindex="-1" aria-describedby="email-hint">
+        <p class="hint" id="email-hint">
+          Your invitation was issued for this address, so it cannot be changed here.
+          Ask an admin for a new invitation if it is wrong.
+        </p>
+      </div>
       <div class="form-group">
         <label for="username">Username</label>
         <input type="text" id="username" name="username" value="{{ username|default('') }}"
                autocomplete="username" minlength="3" maxlength="64" required autofocus>
-      </div>
-      <div class="form-group">
-        <label for="email">Email</label>
-        <input type="email" id="email" name="email" value="{{ email|default('') }}"
-               autocomplete="email" required>
+        <p class="hint">Letters, numbers, hyphens and underscores</p>
       </div>
       <div class="form-group">
         <label for="password">Password</label>

--- a/templates/request_permission.html
+++ b/templates/request_permission.html
@@ -2,10 +2,39 @@
 {% block title %}Access Required — PixelVault{% endblock %}
 
 {% block content %}
+{#
+  Where a share-link visitor with no account lands. Until invites, this page was a
+  dead end that happened to work: every album route is @login_required, so the
+  visitor followed the "Sign up" link and registered themselves. That path is gone
+  (design §8, §11 Q6), so the page has to answer the question it used to dodge —
+  who do I ask?
+
+  The address comes from ADMIN_CONTACT (injected app-wide by routes/auth.py, and
+  falling back to MAIL_FROM). A self-hosted box may have neither set, so the copy
+  degrades to advice that is still actionable — the person who sent the link can
+  always reach whoever runs the server — rather than rendering a blank space where
+  a name should be.
+#}
 <div class="empty-state" style="padding: 6rem 2rem;">
   <div class="icon">🔒</div>
   <h3>Access Required</h3>
   <p>You need to be signed in to view this album.</p>
   <a href="{{ url_for('login', next=request.url) }}" class="btn btn-primary">Sign in to continue</a>
+
+  <p style="margin-top: 2rem; font-size: 0.9rem;">
+    Don't have an account? PixelVault is invite-only, so accounts are created from an
+    invitation link rather than a sign-up form.
+    {% if admin_contact %}
+      Ask
+      {% if '@' in admin_contact %}
+        <a href="mailto:{{ admin_contact }}">{{ admin_contact }}</a>
+      {% else %}
+        {{ admin_contact }}
+      {% endif %}
+      for one.
+    {% else %}
+      Ask the person who shared this album for an invitation.
+    {% endif %}
+  </p>
 </div>
 {% endblock %}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -211,8 +211,8 @@ class Ref:
         return f"Ref({self.__dict__})"
 
 
-def _make_user(username, email, password="correct horse battery staple"):
-    user = User(username=username, email=email, is_admin=False)
+def _make_user(username, email, password="correct horse battery staple", is_admin=False):
+    user = User(username=username, email=email, is_admin=is_admin)
     # set_password runs 600k PBKDF2 rounds; assigning the hash directly keeps
     # the suite fast. No test authenticates by password — see `login`.
     user.password_hash = "pbkdf2:sha256:600000$test$deadbeef"
@@ -233,6 +233,18 @@ def other_user(app):
     """A second, unrelated user — used to prove sessions are not cross-reachable."""
     with app.app_context():
         return _make_user("mallory", "mallory@example.com")
+
+
+@pytest.fixture
+def admin_user(app):
+    """An administrator — the only identity the /admin routes answer to.
+
+    Separate from ``user`` rather than a flag on it, because the invite tests need
+    both at once: one caller who may issue invites and one who may not, in the same
+    test, to show the authorisation boundary is a boundary and not a redirect.
+    """
+    with app.app_context():
+        return _make_user("root", "root@example.com", is_admin=True)
 
 
 @pytest.fixture
@@ -270,6 +282,14 @@ def client(app, user):
     """A test client logged in as ``user``."""
     test_client = app.test_client()
     login(test_client, user)
+    return test_client
+
+
+@pytest.fixture
+def admin_client(app, admin_user):
+    """A test client logged in as ``admin_user``."""
+    test_client = app.test_client()
+    login(test_client, admin_user)
     return test_client
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,6 +67,16 @@ TEST_MAX_INFLIGHT_MB = 4
 #: Per-user open-session quota. Three, so the test needs four inits, not eleven.
 TEST_MAX_SESSIONS = 3
 TEST_TTL_HOURS = 24
+#: Invite link lifetime for the run. Tests that need an expired invite backdate
+#: the row rather than waiting, so the value only has to be stable, not short.
+TEST_INVITE_TTL_HOURS = 72
+TEST_INVITE_COOLDOWN_SECONDS = 60
+#: Origin every invite link in the suite is expected to be built from.
+TEST_PUBLIC_BASE_URL = "https://vault.test.invalid"
+TEST_MAIL_FROM = "pixelvault@test.invalid"
+#: Short enough that a test asserting the timeout reaches the socket can tell it
+#: apart from smtplib's own default of "no timeout".
+TEST_MAIL_TIMEOUT_SECONDS = 5
 
 _TEST_ENV = {
     "SECRET_KEY": "test-secret-key-not-used-in-production",
@@ -84,6 +94,18 @@ _TEST_ENV = {
     "ADMIN_USERNAME": "",
     "ADMIN_EMAIL": "",
     "ADMIN_PASSWORD": "",
+    # Mail: deliberately no SMTP_HOST, so build_mailer() picks ConsoleMailer and
+    # the suite has no way to open a socket even if a test forgets the `mailer`
+    # fixture. Selection tests override the module constants directly instead —
+    # see test_mailer.py.
+    "PUBLIC_BASE_URL": TEST_PUBLIC_BASE_URL,
+    "MAIL_ENABLED": "true",
+    "SMTP_HOST": "",
+    "MAIL_FROM": TEST_MAIL_FROM,
+    "MAIL_FROM_NAME": "PixelVault",
+    "MAIL_TIMEOUT_SECONDS": str(TEST_MAIL_TIMEOUT_SECONDS),
+    "INVITE_TTL_HOURS": str(TEST_INVITE_TTL_HOURS),
+    "INVITE_RESEND_COOLDOWN_SECONDS": str(TEST_INVITE_COOLDOWN_SECONDS),
 }
 os.environ.update(_TEST_ENV)
 
@@ -91,6 +113,7 @@ os.environ.update(_TEST_ENV)
 from pixelvault import create_app  # noqa: E402
 from pixelvault import uploads as uploads_module  # noqa: E402
 from pixelvault.extensions import db, limiter  # noqa: E402
+from pixelvault.mailer import MemoryMailer  # noqa: E402
 from pixelvault.models import Album, Base, Photo, UploadSession, User  # noqa: E402
 
 from .protocol import ProtocolClient  # noqa: E402
@@ -137,6 +160,25 @@ def reset_state(app):
         # deliberately holding; the cleanup tests set it back to 0 themselves.
         uploads_module._last_sweep_at = float("inf")
     yield
+
+
+@pytest.fixture
+def mailer(app):
+    """Swap a :class:`MemoryMailer` in for the duration of one test.
+
+    Replaces the backend in ``app.extensions`` rather than any module global,
+    because that is where ``extensions.mailer`` resolves on every call — so code
+    that imported the proxy at load time picks this up, and the swap survives the
+    session-scoped ``app`` fixture without leaking into the next test.
+
+    Yields the MemoryMailer itself; ``.outbox`` is the list of messages that would
+    have been sent.
+    """
+    previous = app.extensions.get("mailer")
+    memory = MemoryMailer()
+    app.extensions["mailer"] = memory
+    yield memory
+    app.extensions["mailer"] = previous
 
 
 @pytest.fixture

--- a/tests/test_invite_access.py
+++ b/tests/test_invite_access.py
@@ -1,0 +1,527 @@
+"""The acceptance flow as an authorisation boundary.
+
+``test_invite_lifecycle.py`` proves the state machine in ``invites.py`` is correct.
+This module proves the three HTTP routes over it cannot be talked out of it, which
+is a different question: every test here is written from the position of someone
+holding one invite link and wanting something it does not entitle them to.
+
+The property the whole module exists for is the first section. An invitation
+authorizes **one address**, and the address the account is created with is read off
+the server-side row — never from the submitted form. If that ever stops being true
+the whitelist becomes decorative: anyone who receives any invite can register as
+anyone, including an address an admin has deliberately never authorized.
+
+Everything else here is the supporting cast: the token must leave the URL, a dead
+link must say *which* kind of dead it is, a live session must not be able to absorb
+an invitation, and the rules ``/register`` used to enforce must still be enforced
+now that it is gone.
+"""
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from pixelvault import invites
+from pixelvault.extensions import db
+from pixelvault.models import AllowedEmail, User
+
+from tests.conftest import Ref
+
+#: The address the invite in these tests is issued for.
+INVITED_EMAIL = "invitee@example.com"
+#: The address an attacker would rather have. Never authorized by anyone.
+ATTACKER_EMAIL = "attacker@evil.example"
+
+GOOD_PASSWORD = "correct horse battery staple"
+GOOD_USERNAME = "newcomer"
+
+#: Rate limits from design §10. Asserted behaviourally — the point is that a
+#: caller is actually refused, not that a decorator is present.
+INVITE_LINK_BUDGET = 60
+INVITE_SUBMIT_BUDGET = 20
+
+
+# ── Fixtures ───────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def invite(app):
+    """A live, unaccepted invitation. ``.token`` is the plaintext, readable once."""
+    with app.app_context():
+        row, token = invites.issue(
+            db.session, INVITED_EMAIL, prefill_username="suggested",
+        )
+        return Ref(id=row.id, email=row.email, token=token,
+                   prefill_username=row.prefill_username)
+
+
+@pytest.fixture
+def invite_row(app):
+    """Return a callable re-reading an invite row as a detached snapshot."""
+    def _get(invite_id):
+        with app.app_context():
+            row = db.session.get(AllowedEmail, invite_id)
+            if row is None:
+                return None
+            return Ref(id=row.id, email=row.email, state=row.state,
+                       token_hash=row.token_hash, accepted_at=row.accepted_at,
+                       accepted_user_id=row.accepted_user_id)
+    return _get
+
+
+@pytest.fixture
+def accounts(app):
+    """Return a callable listing every User as ``(username, email)`` pairs."""
+    def _list():
+        with app.app_context():
+            return [(u.username, u.email) for u in db.session.query(User).all()]
+    return _list
+
+
+@pytest.fixture
+def expire(app):
+    """Backdate an invite past its TTL, which is indistinguishable from waiting."""
+    def _expire(invite_id):
+        with app.app_context():
+            row = db.session.get(AllowedEmail, invite_id)
+            row.token_issued_at = datetime.utcnow() - timedelta(days=30)
+            row.expires_at = datetime.utcnow() - timedelta(hours=1)
+            db.session.commit()
+    return _expire
+
+
+def open_link(client, token):
+    """Click an invite link: the GET that moves the token into the session."""
+    return client.get(f"/invite/{token}")
+
+
+def submit(client, username=GOOD_USERNAME, password=GOOD_PASSWORD, confirm=None, **extra):
+    """POST the acceptance form. ``extra`` lets a test add fields a browser never sends."""
+    data = {
+        "username": username,
+        "password": password,
+        "confirm_password": password if confirm is None else confirm,
+    }
+    data.update(extra)
+    return client.post("/invite", data=data)
+
+
+def logged_in_id(client):
+    """The user id Flask-Login has on this client's session, or None."""
+    with client.session_transaction() as sess:
+        return sess.get("_user_id")
+
+
+def stashed_token(client):
+    """The invite token currently held in this client's session, or None."""
+    with client.session_transaction() as sess:
+        return sess.get("invite_token")
+
+
+# ── The property the feature exists for ────────────────────────────────────
+
+def test_a_posted_email_is_ignored_in_favour_of_the_invited_address(
+        anon_client, invite, accounts, invite_row):
+    """The single most important assertion in the suite (design §7.2).
+
+    The form does not render a named email field, so a browser cannot send one —
+    but a form is not a security boundary, and anyone can post whatever they like.
+    What makes the address trustworthy is that the server reads it off the invite
+    row inside ``invites.consume`` and never looks at ``request.form['email']``.
+
+    If this test ever fails, the whitelist is over: the holder of an invite for any
+    address can mint an account for any other, including one an admin refused.
+    """
+    open_link(anon_client, invite.token)
+
+    response = submit(anon_client, email=ATTACKER_EMAIL)
+
+    assert response.status_code == 302
+    assert accounts() == [(GOOD_USERNAME, INVITED_EMAIL)]
+    assert invite_row(invite.id).state.name == "ACCEPTED"
+
+
+def test_a_posted_email_cannot_be_smuggled_past_a_direct_post(
+        anon_client, invite, accounts):
+    """The same attack without ever loading the form, in case a future refactor
+    starts trusting fields it believes only its own template can produce."""
+    open_link(anon_client, invite.token)
+
+    submit(anon_client, email=ATTACKER_EMAIL, Email=ATTACKER_EMAIL.upper(),
+           invite_email=ATTACKER_EMAIL, token="anything at all")
+
+    assert [email for _, email in accounts()] == [INVITED_EMAIL]
+
+
+def test_the_rendered_form_submits_no_email_field(anon_client, invite):
+    """Defence in depth for the test above: the address is displayed, not posted.
+
+    A named-but-readonly input would still be submitted, which puts an
+    attacker-editable copy of the most important value in the flow one careless
+    ``request.form.get('email')`` away from being believed.
+    """
+    open_link(anon_client, invite.token)
+    body = anon_client.get("/invite").get_data(as_text=True)
+
+    assert INVITED_EMAIL in body
+    assert 'name="email"' not in body
+    assert "readonly" in body
+
+
+# ── The token leaves the URL ───────────────────────────────────────────────
+
+def test_the_link_redirects_to_a_url_that_carries_no_token(anon_client, invite):
+    """Design §11 Q5. ``Referrer-Policy`` stops the token leaking cross-origin, but
+    a token in the path is still copied into nginx access logs, browser history and
+    every "here is the page I'm on" message a confused invitee sends."""
+    response = open_link(anon_client, invite.token)
+
+    assert response.status_code == 302
+    assert response.headers["Location"].endswith("/invite")
+    assert invite.token not in response.headers["Location"]
+
+
+def test_the_flow_completes_through_the_session_alone(anon_client, invite, accounts):
+    """The redirect target has no token, so the form and the POST have to work from
+    the session copy. If they did not, the clean URL would be cosmetic and the
+    token would have to come back into the query string to make the flow work."""
+    open_link(anon_client, invite.token)
+    assert stashed_token(anon_client) == invite.token
+
+    assert anon_client.get("/invite").status_code == 200
+    assert submit(anon_client).status_code == 302
+    assert accounts() == [(GOOD_USERNAME, INVITED_EMAIL)]
+
+
+# ── Happy path ─────────────────────────────────────────────────────────────
+
+def test_click_form_submit_creates_the_account_and_signs_the_user_in(
+        anon_client, invite, invite_row, accounts):
+    """The whole flow end to end, asserting each of the four things it must do."""
+    assert open_link(anon_client, invite.token).status_code == 302
+
+    form = anon_client.get("/invite").get_data(as_text=True)
+    # The admin's suggestion is offered, and is editable — design §11 Q8.
+    assert INVITED_EMAIL in form
+    assert 'value="suggested"' in form
+
+    response = submit(anon_client, username="chosen-name")
+
+    assert response.headers["Location"].endswith("/dashboard")
+    assert accounts() == [("chosen-name", INVITED_EMAIL)]
+
+    row = invite_row(invite.id)
+    assert row.state.name == "ACCEPTED"
+    assert row.accepted_at is not None
+    # Single use is enforced by nulling the hash, in the same transaction.
+    assert row.token_hash is None
+
+    with anon_client.session_transaction() as sess:
+        assert sess.get("_user_id") is not None
+        # The spent token is dropped, so a browser-history "back" cannot replay it.
+        assert "invite_token" not in sess
+    assert row.accepted_user_id == int(logged_in_id(anon_client))
+
+
+def test_a_used_link_cannot_be_replayed(app, invite, accounts):
+    """A second click on the same link, from a browser that never saw the first.
+
+    The wording is the interesting half: ``consume`` nulls the hash, so the replay
+    is genuinely indistinguishable from a typo and the page must not claim to know
+    which it was.
+    """
+    first = app.test_client()
+    open_link(first, invite.token)
+    submit(first, username="first-arrival")
+
+    second = app.test_client()
+    response = open_link(second, invite.token)
+
+    assert response.status_code == 404
+    assert len(accounts()) == 1
+    assert stashed_token(second) is None
+
+
+# ── The four refusals ──────────────────────────────────────────────────────
+
+def test_an_unknown_token_is_worded_for_typos_and_replays_at_once(anon_client):
+    """``InvalidInvite`` serves two readers who cannot be told apart (design §13).
+
+    One mistyped or truncated the link; the other already used it, because
+    acceptance nulls the hash and leaves nothing to match. The copy has to give
+    both of them their next step without asserting which one they are.
+    """
+    response = anon_client.get("/invite/not-a-real-token")
+    body = response.get_data(as_text=True)
+
+    assert response.status_code == 404
+    assert "not valid" in body
+    # The mistyped-link reader.
+    assert "copied the whole link" in body
+    # The already-registered reader.
+    assert "sign in below" in body.lower()
+    assert "stops working the moment it is accepted" in body
+
+
+def test_an_expired_link_says_so_and_names_the_fix(anon_client, invite, expire):
+    """410 Gone: it was real, it is not any more. The only fix is an admin resend,
+    so the message says that rather than leaving them re-clicking."""
+    expire(invite.id)
+
+    response = anon_client.get(f"/invite/{invite.token}")
+    body = response.get_data(as_text=True)
+
+    assert response.status_code == 410
+    assert "expired" in body
+    assert "send you a new one" in body
+
+
+def test_an_accepted_invite_points_at_the_login_page(app, anon_client, invite):
+    """``AlreadyAccepted`` out of ``validate`` needs a row that is accepted *and*
+    still holds a token, which the normal path never produces — ``consume`` nulls
+    the hash. It is reachable from a hand-edited row, a restored backup, or a
+    future path that stamps acceptance elsewhere, and the wording is what stops a
+    person who already has an account from asking for another invitation.
+    """
+    with app.app_context():
+        row = db.session.get(AllowedEmail, invite.id)
+        row.accepted_at = datetime.utcnow()
+        db.session.commit()
+
+    response = anon_client.get(f"/invite/{invite.token}")
+    body = response.get_data(as_text=True)
+
+    assert response.status_code == 409
+    assert "already been accepted" in body
+    assert "the account exists" in body
+
+
+def test_the_form_without_any_invitation_explains_there_is_no_signup_page(anon_client):
+    """Someone typing /invite, or coming back after their session cookie expired.
+
+    Distinct from the three link faults: nothing is wrong with any link, they just
+    have not opened one, and the useful thing to say is that no public form exists.
+    """
+    response = anon_client.get("/invite")
+    body = response.get_data(as_text=True)
+
+    assert response.status_code == 403
+    assert "Open the invitation link you were sent" in body
+    assert "invite-only" in body
+
+
+def test_posting_without_any_invitation_is_refused_the_same_way(anon_client, accounts):
+    """The POST is the half that matters — a form is not a boundary, and the
+    acceptance route must refuse a hand-crafted request with no session behind it."""
+    response = submit(anon_client)
+
+    assert response.status_code == 403
+    assert accounts() == []
+
+
+# ── A stash that has gone stale since the click ────────────────────────────
+
+def test_a_token_rotated_since_the_click_is_refused(app, anon_client, invite, accounts):
+    """An admin pressing Resend or Copy link between the GET and the POST.
+
+    Rotation mints a new token and kills the old one (design §4), so the copy in
+    this session is now worthless. The POST re-validates rather than trusting the
+    GET's verdict, which is the only thing that catches this.
+    """
+    open_link(anon_client, invite.token)
+    with app.app_context():
+        invites.rotate(db.session, db.session.get(AllowedEmail, invite.id))
+
+    response = submit(anon_client)
+
+    assert response.status_code == 404
+    assert accounts() == []
+    # Dead tokens are dropped, so /invite does not keep refusing forever.
+    assert stashed_token(anon_client) is None
+
+
+def test_a_token_consumed_in_another_tab_is_refused(app, anon_client, invite, accounts):
+    """Two tabs on one invitation, or a double-submit. The second one loses."""
+    open_link(anon_client, invite.token)
+
+    other_tab = app.test_client()
+    open_link(other_tab, invite.token)
+    submit(other_tab, username="first-arrival")
+
+    response = submit(anon_client, username="second-arrival")
+
+    assert response.status_code == 404
+    assert accounts() == [("first-arrival", INVITED_EMAIL)]
+
+
+def test_an_expired_stash_is_refused_at_submit_time(anon_client, invite, expire, accounts):
+    """The TTL can lapse while the form sits open. Re-validation catches that too."""
+    open_link(anon_client, invite.token)
+    expire(invite.id)
+
+    response = submit(anon_client)
+
+    assert response.status_code == 410
+    assert accounts() == []
+
+
+# ── A live session must not absorb an invitation ───────────────────────────
+
+def test_an_invitation_is_refused_while_someone_is_signed_in(
+        client, user, invite, invite_row):
+    """Design §7.2 allows logging the visitor out or refusing; this app refuses.
+
+    Logging them out is a side effect a stranger can trigger in someone else's
+    browser with a URL, and the server cannot tell whether the signed-in person is
+    the invitee anyway. Refusing leaves both the session and the invitation intact,
+    so whoever the link was actually sent to can still use it.
+    """
+    response = client.get(f"/invite/{invite.token}")
+
+    assert response.status_code == 302
+    assert response.headers["Location"].endswith("/dashboard")
+    # Their session survives, and the invitation is untouched and still live.
+    assert logged_in_id(client) == str(user.id)
+    assert stashed_token(client) is None
+    assert invite_row(invite.id).state.name == "ISSUED"
+
+
+def test_a_signed_in_visitor_cannot_accept_by_posting_directly(
+        app, client, user, invite, invite_row, accounts):
+    """The refusal has to hold on the POST as well, otherwise it is only advice."""
+    anonymous = app.test_client()
+    open_link(anonymous, invite.token)
+    # Hand the signed-in browser the same session token the anonymous one holds.
+    with client.session_transaction() as sess:
+        sess["invite_token"] = invite.token
+
+    response = submit(client, username="second-account")
+
+    assert response.status_code == 302
+    assert response.headers["Location"].endswith("/dashboard")
+    assert [name for name, _ in accounts()] == [user.username]
+    assert invite_row(invite.id).accepted_at is None
+
+
+# ── The rules /register used to enforce ────────────────────────────────────
+
+@pytest.mark.parametrize("fields, expected", [
+    ({"username": "ab"}, "at least 3 characters"),
+    ({"username": "a" * 65}, "64 characters or fewer"),
+    ({"username": "bad name!"}, "letters, numbers, hyphens, and underscores"),
+    ({"password": "short"}, "at least 8 characters"),
+    ({"password": "x" * 1025}, "Password is too long"),
+    ({"confirm": "something else"}, "Passwords do not match"),
+])
+def test_username_and_password_rules_survive_the_move_from_register(
+        anon_client, invite, accounts, fields, expected):
+    """The same rules, with the same wording, as the deleted ``/register`` route.
+
+    Quietly relaxing one during a move is how a password minimum disappears without
+    anyone deciding to remove it. The 1024-character ceiling in particular is not a
+    style rule: ``set_password`` runs 600k PBKDF2 rounds, so an unbounded password
+    is a way to spend a worker thread on request.
+    """
+    open_link(anon_client, invite.token)
+
+    response = submit(anon_client, **fields)
+
+    assert response.status_code == 200
+    assert expected in response.get_data(as_text=True)
+    assert accounts() == []
+
+
+def test_a_duplicate_username_is_refused_with_the_invite_still_live(
+        anon_client, user, invite, invite_row):
+    """Checked before ``consume`` so the reader gets "pick another name" rather than
+    the generic collision backstop — and so the invitation is not spent on a
+    submission that could not have worked."""
+    open_link(anon_client, invite.token)
+
+    response = submit(anon_client, username=user.username)
+
+    assert response.status_code == 200
+    assert "Username already taken." in response.get_data(as_text=True)
+    assert invite_row(invite.id).accepted_at is None
+
+
+def test_an_address_that_already_has_an_account_is_sent_to_login(
+        app, anon_client, invite, invite_row):
+    """An admin who issued an invite and then created the account by hand.
+
+    Without this check ``consume`` fails on the unique index on ``user.email`` and
+    reports a username collision, sending the reader off to invent names that can
+    never work.
+    """
+    with app.app_context():
+        existing = User(username="already-here", email=INVITED_EMAIL)
+        existing.password_hash = "pbkdf2:sha256:600000$test$deadbeef"
+        db.session.add(existing)
+        db.session.commit()
+
+    open_link(anon_client, invite.token)
+    response = submit(anon_client)
+
+    assert response.status_code == 200
+    assert "An account already exists for this address" in response.get_data(as_text=True)
+    assert invite_row(invite.id).accepted_at is None
+
+
+# ── Public registration is gone ────────────────────────────────────────────
+
+@pytest.mark.parametrize("method", ["get", "post"])
+def test_register_is_404_not_a_redirect(anon_client, method):
+    """Design §8. A redirect to /login would say the page moved; it did not, it was
+    removed, and the only way in now is a link an admin issued."""
+    response = getattr(anon_client, method)("/register")
+
+    assert response.status_code == 404
+
+
+def test_the_login_page_no_longer_offers_a_signup_link(anon_client):
+    """And says why, so the missing link does not read as a broken page."""
+    body = anon_client.get("/login").get_data(as_text=True)
+
+    assert "Sign up" not in body
+    assert "invite-only" in body
+
+
+def test_the_access_required_page_names_someone_to_ask(app, anon_client, album):
+    """An accountless share-link guest used to self-register from here (design §11
+    Q6). That path is closed, so the page has to name a contact instead of ending
+    at a sign-in button they cannot use."""
+    body = anon_client.get(f"/album/{album.token}").get_data(as_text=True)
+
+    assert "invite-only" in body
+    # ADMIN_CONTACT falls back to MAIL_FROM, which conftest sets for the run.
+    assert app.jinja_env.globals is not None
+    assert "pixelvault@test.invalid" in body
+
+
+# ── Rate limits (design §10) ───────────────────────────────────────────────
+
+def test_clicking_links_is_throttled(anon_client):
+    """60/hour per IP on the link endpoint.
+
+    Guessing a 256-bit token is not the threat this bounds — the odds are
+    indistinguishable from zero either way. What it bounds is an unauthenticated
+    endpoint that does a database lookup per request being used as a cheap way to
+    make the app work.
+    """
+    statuses = [anon_client.get(f"/invite/token-{n}").status_code
+                for n in range(INVITE_LINK_BUDGET + 2)]
+
+    assert statuses[0] == 404
+    assert statuses.index(429) == INVITE_LINK_BUDGET
+
+
+def test_submitting_the_form_is_throttled_harder(anon_client):
+    """20/hour per IP, a third of the link budget.
+
+    The POST is the expensive one — it hashes a password with 600k PBKDF2 rounds on
+    the way to creating a row — and no honest invitee submits it more than a
+    handful of times.
+    """
+    statuses = [submit(anon_client).status_code for _ in range(INVITE_SUBMIT_BUDGET + 2)]
+
+    assert statuses[0] == 403
+    assert statuses.index(429) == INVITE_SUBMIT_BUDGET

--- a/tests/test_invite_admin.py
+++ b/tests/test_invite_admin.py
@@ -1,0 +1,691 @@
+"""The admin half of invites: issuing, resending, the copy-link fallback, revoking.
+
+These are the routes where the three invite modules meet, so the tests are about
+the *seams* rather than about any one of them:
+
+* the lifecycle (``invites.py``) and delivery (``emails.py``) are ordered so that a
+  relay outage cannot cost an invite — the row commits first, and the token minted
+  before a failed send still validates afterwards;
+* a renewal always rotates, so proving the new token works is only half the
+  assertion — the old one must have stopped working in the same request;
+* the copy-link fallback exists precisely for the case where mail is broken, so it
+  is asserted to send *nothing* and to build its URL from ``PUBLIC_BASE_URL``
+  rather than from the request's ``Host`` (design §6);
+* and every one of these routes creates or hands out a credential, so the
+  authorisation boundary gets direct tests rather than being assumed from the
+  decorators.
+
+Tokens are read back out of the ``MemoryMailer`` outbox and out of the flashed
+link, because that is the only place a plaintext token ever exists — the database
+holds a SHA-256. Anything a test cannot get that way, an admin cannot get either.
+
+Cooldown and TTL come from ``conftest._TEST_ENV`` (60s, 72h) and are moved by
+backdating rows, never by sleeping.
+"""
+
+import re
+from datetime import datetime, timedelta
+
+import pytest
+
+from pixelvault import invites
+from pixelvault.extensions import db
+from pixelvault.mailer import MailError
+from pixelvault.models import AllowedEmail, InviteState, User
+
+from tests.conftest import TEST_PUBLIC_BASE_URL, Ref, _make_user, login
+
+#: The link as it appears in both an email body and a flashed message. The token
+#: alphabet is ``secrets.token_urlsafe``'s, which needs no HTML escaping — so the
+#: same pattern works against rendered markup.
+INVITE_LINK_RE = re.compile(
+    re.escape(TEST_PUBLIC_BASE_URL) + r"/invite/([A-Za-z0-9_-]{20,})"
+)
+
+ADDRESS = "newcomer@example.com"
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+class RefusingMailer:
+    """A relay that accepts the connection and then rejects the message.
+
+    The interesting failure shape: composition succeeded, so the token exists and
+    the row is stamped, and only delivery is lost. It keeps what it was handed in
+    :attr:`attempted` so a test can still read the token an invitee never received
+    — which is how "the invite survived the outage" is proved rather than assumed.
+    """
+
+    def __init__(self, reason="relay refused: 550 5.7.1 message rejected"):
+        self.attempted = []
+        self.reason = reason
+
+    def send(self, message):
+        self.attempted.append(message)
+        raise MailError(self.reason)
+
+
+@pytest.fixture
+def broken_mailer(app):
+    """Swap in a relay that always refuses, the way the ``mailer`` fixture swaps in memory."""
+    previous = app.extensions.get("mailer")
+    refusing = RefusingMailer()
+    app.extensions["mailer"] = refusing
+    yield refusing
+    app.extensions["mailer"] = previous
+
+
+def token_in(message):
+    """Return the invite token carried by an ``EmailMessage``'s plain-text part.
+
+    The text part specifically: it is the one the design guarantees is complete
+    and clickable, so reading the token from anywhere else would let a broken
+    text part pass unnoticed.
+    """
+    body = message.get_body(preferencelist=("plain",)).get_content()
+    match = INVITE_LINK_RE.search(body)
+    assert match, f"no invite link in the text part:\n{body}"
+    return match.group(1)
+
+
+def token_in_page(response):
+    """Return the invite token flashed onto a rendered page."""
+    match = INVITE_LINK_RE.search(response.get_data(as_text=True))
+    assert match, "no invite link on the page"
+    return match.group(1)
+
+
+def row_for(app, email):
+    """Snapshot the ``AllowedEmail`` row for an address, or None."""
+    with app.app_context():
+        row = db.session.query(AllowedEmail).filter_by(email=email).one_or_none()
+        if row is None:
+            return None
+        return Ref(
+            id=row.id,
+            email=row.email,
+            note=row.note,
+            prefill_username=row.prefill_username,
+            state=row.state.value,
+            has_token=row.token_hash is not None,
+            token_hash=row.token_hash,
+            send_count=row.send_count,
+            last_send_error=row.last_send_error,
+            last_sent_at=row.last_sent_at,
+            expires_at=row.expires_at,
+            invited_by_id=row.invited_by_id,
+        )
+
+
+def validates(app, token):
+    """Return the address a token authorizes, or None if it no longer works."""
+    with app.app_context():
+        try:
+            return invites.validate(db.session, token).email
+        except invites.InviteError:
+            return None
+
+
+def make_legacy(app, email="oldtimer@example.com", note="from before invites"):
+    """Create a whitelist row of the kind that predates this feature: no token at all.
+
+    Written straight to the model rather than through ``invites.issue``, because
+    ``issue`` cannot produce one — which is the whole point. Every allowed_email row
+    in the existing production database looks like this, and both admin actions have
+    to work on it or those people are stranded once /register goes away.
+    """
+    with app.app_context():
+        row = AllowedEmail(email=email, note=note)
+        db.session.add(row)
+        db.session.commit()
+        assert row.state is InviteState.LEGACY
+        return Ref(id=row.id, email=row.email)
+
+
+def make_invite(app, email=ADDRESS, **stamps):
+    """Issue an invite directly and return ``(Ref, plaintext_token)``.
+
+    For tests about resend and copy-link, which need a row that already exists
+    without going through the add form first. ``stamps`` are attributes written
+    onto the row afterwards — backdating ``last_sent_at`` past the cooldown, or
+    ``expires_at`` into the past.
+    """
+    with app.app_context():
+        invite, token = invites.issue(db.session, email)
+        for field, value in stamps.items():
+            setattr(invite, field, value)
+        db.session.commit()
+        return Ref(id=invite.id, email=invite.email), token
+
+
+def cooled_down():
+    """A ``last_sent_at`` far enough in the past that the resend cooldown has lapsed."""
+    return datetime.utcnow() - timedelta(hours=1)
+
+
+# ── Issuing (design §7.1) ──────────────────────────────────────────────────
+
+def test_adding_an_email_issues_an_invite_and_sends_exactly_one_message(
+        app, admin_client, admin_user, mailer):
+    """The whole point of the change: one admin action, one live invite, one email."""
+    response = admin_client.post('/admin/email/add', data={
+        'email': ADDRESS,
+        'note': 'Alice from the climbing gym',
+        'prefill_username': 'alice',
+    })
+
+    assert response.status_code == 302
+    assert len(mailer.outbox) == 1
+
+    message = mailer.outbox[0]
+    assert message['To'] == ADDRESS
+    # The token in the email is the token the app will accept. Anything less than
+    # this round trip would pass with a message that carries a stale or wrong link.
+    assert validates(app, token_in(message)) == ADDRESS
+
+    row = row_for(app, ADDRESS)
+    assert row.state == 'sent'
+    assert row.send_count == 1
+    assert row.last_send_error == ''
+    assert row.note == 'Alice from the climbing gym'
+    assert row.prefill_username == 'alice'
+    # Audit trail: which admin issued it (design §4).
+    assert row.invited_by_id == admin_user.id
+
+
+def test_the_address_is_normalised_before_it_becomes_a_row(app, admin_client, mailer):
+    """Case and surrounding whitespace must not be able to mint a second whitelist entry."""
+    admin_client.post('/admin/email/add', data={'email': '  NewComer@Example.COM  '})
+
+    assert row_for(app, ADDRESS) is not None
+
+
+@pytest.mark.parametrize('bad', ['not-an-email', 'missing@tld', 'two@@at.example.com', ''])
+def test_an_address_registration_would_reject_is_refused_here_too(
+        app, admin_client, mailer, bad):
+    """The add form now enforces RE_EMAIL, the pattern acceptance enforces.
+
+    The old ``'@' in email`` check was the weaker of the two, so an address could be
+    authorized that could never be used — and now, one that an invite email would be
+    fired at pointlessly.
+    """
+    admin_client.post('/admin/email/add', data={'email': bad})
+
+    with app.app_context():
+        assert db.session.query(AllowedEmail).count() == 0
+    assert mailer.outbox == []
+
+
+def test_a_send_failure_still_leaves_a_usable_invite(app, admin_client, broken_mailer):
+    """An SMTP outage must cost the delivery, never the invite (design §7.1).
+
+    The row is committed before anything is sent, so what is left behind is a live
+    token, an honest SEND_FAILED state, and the relay's own complaint — everything
+    an admin needs to resend or to hand the link over by other means.
+    """
+    response = admin_client.post('/admin/email/add', data={'email': ADDRESS},
+                                 follow_redirects=True)
+
+    row = row_for(app, ADDRESS)
+    assert row is not None
+    assert row.state == 'send_failed'
+    assert row.send_count == 1
+    assert broken_mailer.reason in row.last_send_error
+    # The credential itself is untouched: the token composed into the message the
+    # relay bounced is still the one the app would accept.
+    assert validates(app, token_in(broken_mailer.attempted[0])) == ADDRESS
+    # And the admin is pointed at the fallback rather than left to guess.
+    assert 'Copy link' in response.get_data(as_text=True)
+
+
+def test_adding_an_address_that_already_has_an_account_is_refused(
+        app, admin_client, mailer):
+    """Nothing to invite — and no email fired at someone who is already a member."""
+    with app.app_context():
+        _make_user('bob', ADDRESS)
+
+    response = admin_client.post('/admin/email/add', data={'email': ADDRESS},
+                                 follow_redirects=True)
+
+    page = response.get_data(as_text=True)
+    assert 'already has an account' in page
+    assert mailer.outbox == []
+    with app.app_context():
+        assert db.session.query(AllowedEmail).count() == 0
+
+
+def test_adding_an_address_that_is_already_invited_points_at_resend(
+        app, admin_client, mailer):
+    """The distinct refusal: the invite exists, so the action wanted is Resend.
+
+    Answering this with the same message as the already-registered case is what
+    the old route did, and it is a dead end — the admin is told "no" without being
+    told what to do instead.
+    """
+    make_invite(app)
+
+    response = admin_client.post('/admin/email/add', data={'email': ADDRESS},
+                                 follow_redirects=True)
+
+    page = response.get_data(as_text=True)
+    assert 'already been invited' in page
+    assert 'Resend' in page
+    # Distinct from the already-registered wording, not a shared shrug.
+    assert 'already has an account' not in page
+    assert mailer.outbox == []
+
+
+# ── Resend (design §7.4) ───────────────────────────────────────────────────
+
+def test_resend_rotates_the_token_and_sends_again(app, admin_client, mailer):
+    """Rotation is half the assertion: the link that was superseded must be dead."""
+    invite, first_token = make_invite(app, last_sent_at=cooled_down())
+
+    response = admin_client.post(f'/admin/invite/{invite.id}/resend')
+
+    assert response.status_code == 302
+    assert len(mailer.outbox) == 1
+    second_token = token_in(mailer.outbox[0])
+
+    assert second_token != first_token
+    assert validates(app, second_token) == ADDRESS
+    # Hashing means a link cannot be re-shown, so a resend has to mint — and the
+    # previous one stops working the moment it does.
+    assert validates(app, first_token) is None
+
+    row = row_for(app, ADDRESS)
+    assert row.state == 'sent'
+    # One attempt, not two: make_invite issues without sending, so this resend is
+    # the row's first actual delivery. mark_sent counts attempts and is called
+    # exactly once per send — by emails.send_invite, never by the route.
+    assert row.send_count == 1
+
+
+def test_resend_inside_the_cooldown_says_when_and_does_not_rotate(
+        app, admin_client, mailer):
+    """A refusal must cost the invitee nothing: the link they hold keeps working.
+
+    The cooldown is checked before rotating for exactly this reason. Rotating first
+    and then refusing would break a live invite as a side effect of a throttle.
+    """
+    invite, token = make_invite(app, last_sent_at=datetime.utcnow())
+    before = row_for(app, ADDRESS)
+
+    response = admin_client.post(f'/admin/invite/{invite.id}/resend',
+                                 follow_redirects=True)
+
+    page = response.get_data(as_text=True)
+    assert 'more seconds' in page  # names the wait rather than just saying no
+    assert re.search(r'Wait \d+ more seconds', page)
+    assert mailer.outbox == []
+
+    after = row_for(app, ADDRESS)
+    assert after.token_hash == before.token_hash
+    assert after.send_count == before.send_count
+    assert validates(app, token) == ADDRESS
+
+
+def test_resend_on_a_failed_row_clears_the_error_when_it_works(
+        app, admin_client, mailer, broken_mailer):
+    """SEND_FAILED must be recoverable, or the panel nags about a delivery that worked.
+
+    ``emails.send_invite`` owns that bookkeeping through ``mark_sent`` — the routes
+    never call it themselves, which is what keeps ``send_count`` honest.
+    """
+    admin_client.post('/admin/email/add', data={'email': ADDRESS})
+    assert row_for(app, ADDRESS).state == 'send_failed'
+
+    invite = row_for(app, ADDRESS)
+    with app.app_context():
+        row = db.session.get(AllowedEmail, invite.id)
+        row.last_sent_at = cooled_down()
+        db.session.commit()
+
+    app.extensions['mailer'] = mailer  # the relay comes back
+    admin_client.post(f'/admin/invite/{invite.id}/resend')
+
+    row = row_for(app, ADDRESS)
+    assert row.state == 'sent'
+    assert row.last_send_error == ''
+    assert row.send_count == 2
+
+
+def test_resend_on_an_accepted_invite_is_a_no_op(app, admin_client, mailer):
+    """Acceptance is terminal; re-minting there would put a live credential on a finished row."""
+    invite, _ = make_invite(app, last_sent_at=cooled_down())
+    with app.app_context():
+        row = db.session.get(AllowedEmail, invite.id)
+        user = _make_user('newcomer', ADDRESS)
+        row.accepted_at = datetime.utcnow()
+        row.accepted_user_id = user.id
+        row.token_hash = None
+        db.session.commit()
+
+    response = admin_client.post(f'/admin/invite/{invite.id}/resend',
+                                 follow_redirects=True)
+
+    assert 'already registered' in response.get_data(as_text=True)
+    assert mailer.outbox == []
+    assert row_for(app, ADDRESS).state == 'accepted'
+
+
+# ── Copy-link fallback (design §7.3) ───────────────────────────────────────
+
+def test_copy_link_rotates_and_flashes_a_url_without_sending_mail(
+        app, admin_client, mailer):
+    """The path that makes SMTP optional rather than a hard dependency of registration."""
+    invite, first_token = make_invite(app)
+
+    response = admin_client.post(f'/admin/invite/{invite.id}/link',
+                                 follow_redirects=True)
+
+    assert mailer.outbox == []  # nothing left the process
+
+    shown = token_in_page(response)
+    assert shown != first_token
+    assert validates(app, shown) == ADDRESS
+    assert validates(app, first_token) is None
+
+    # Nothing was sent, so the row must not claim otherwise.
+    row = row_for(app, ADDRESS)
+    assert row.state == 'issued'
+    assert row.send_count == 0
+    assert row.last_sent_at is None
+
+
+def test_the_flashed_link_is_built_from_public_base_url(app, admin_client, mailer):
+    """From the configured origin, not the one the request arrived on (design §6).
+
+    ``url_for(_external=True)`` would reconstruct ``http://localhost`` here, and in
+    production it reconstructs whatever ``Host`` and the forwarded headers claim —
+    which is how a spoofed header aims a real invite token at someone else's domain.
+    The absence of the request's own origin from the flashed link is the assertion.
+    """
+    invite, _ = make_invite(app)
+
+    response = admin_client.post(f'/admin/invite/{invite.id}/link',
+                                 follow_redirects=True)
+
+    page = response.get_data(as_text=True)
+    assert f'{TEST_PUBLIC_BASE_URL}/invite/' in page
+    assert 'localhost/invite/' not in page
+
+
+def test_copy_link_is_available_immediately_after_a_failed_send(
+        app, admin_client, broken_mailer):
+    """The fallback must not be gated by the send cooldown.
+
+    It sends nothing, so the mail-bomb argument the cooldown exists for does not
+    apply — and gating it would disable the fallback during the exact minute after
+    a failed send, which is when an admin reaches for it.
+    """
+    admin_client.post('/admin/email/add', data={'email': ADDRESS})
+    invite = row_for(app, ADDRESS)
+
+    response = admin_client.post(f'/admin/invite/{invite.id}/link',
+                                 follow_redirects=True)
+
+    assert validates(app, token_in_page(response)) == ADDRESS
+
+
+# ── LEGACY rows: the existing production whitelist ─────────────────────────
+
+def test_send_invite_works_on_a_legacy_row(app, admin_client, mailer):
+    """A whitelist entry with no token is un-stranded by the same route Resend uses.
+
+    This is the migration path for every address already in the database. Without
+    it those people are silently unable to register once /register goes away in
+    step 7 (design §11 Q9).
+    """
+    legacy = make_legacy(app)
+
+    response = admin_client.post(f'/admin/invite/{legacy.id}/resend')
+
+    assert response.status_code == 302
+    assert len(mailer.outbox) == 1
+    assert validates(app, token_in(mailer.outbox[0])) == legacy.email
+
+    row = row_for(app, legacy.email)
+    assert row.state == 'sent'
+    assert row.note == 'from before invites'  # the row is renewed, not replaced
+
+
+def test_copy_link_works_on_a_legacy_row(app, admin_client, mailer):
+    """The same un-stranding without a relay, for a self-hoster who has no SMTP at all."""
+    legacy = make_legacy(app)
+
+    response = admin_client.post(f'/admin/invite/{legacy.id}/link',
+                                 follow_redirects=True)
+
+    assert validates(app, token_in_page(response)) == legacy.email
+    assert mailer.outbox == []
+    assert row_for(app, legacy.email).state == 'issued'
+
+
+# ── Revoking (design §7.5) ─────────────────────────────────────────────────
+
+def test_removing_a_pending_invite_kills_its_link(app, admin_client, mailer):
+    """Revocation needs no separate mechanism — the token hash lives on the deleted row."""
+    invite, token = make_invite(app)
+
+    admin_client.post(f'/admin/email/{invite.id}/remove')
+
+    assert row_for(app, ADDRESS) is None
+    assert validates(app, token) is None
+
+
+def test_removing_an_accepted_invite_does_not_touch_the_account(app, admin_client):
+    """Deleting the record of an invite must not delete the person it produced.
+
+    ``accepted_user_id`` is a plain nullable FK with no cascade behind it, and this
+    test is what keeps it that way: adding a relationship with
+    ``cascade='all, delete-orphan'`` later would turn "remove from the list" into
+    "delete the user and every album they own".
+    """
+    invite, _ = make_invite(app)
+    with app.app_context():
+        user = _make_user('newcomer', ADDRESS)
+        row = db.session.get(AllowedEmail, invite.id)
+        row.accepted_at = datetime.utcnow()
+        row.accepted_user_id = user.id
+        row.token_hash = None
+        db.session.commit()
+        user_id = user.id
+
+    response = admin_client.post(f'/admin/email/{invite.id}/remove',
+                                 follow_redirects=True)
+
+    assert row_for(app, ADDRESS) is None
+    with app.app_context():
+        survivor = db.session.get(User, user_id)
+        assert survivor is not None
+        assert survivor.email == ADDRESS
+    assert 'account is untouched' in response.get_data(as_text=True)
+
+
+# ── The panel ──────────────────────────────────────────────────────────────
+
+def _one_of_each_state(app):
+    """Create six rows, one in each InviteState, and return them by state name."""
+    rows = {}
+    with app.app_context():
+        accepted, _ = invites.issue(db.session, 'accepted@example.com')
+        accepted.accepted_at = datetime.utcnow()
+        accepted.token_hash = None
+
+        invites.issue(db.session, 'issued@example.com')
+
+        sent, _ = invites.issue(db.session, 'sent@example.com')
+        sent.last_sent_at = datetime.utcnow()
+        sent.send_count = 1
+
+        failed, _ = invites.issue(db.session, 'failed@example.com')
+        failed.last_sent_at = datetime.utcnow()
+        failed.send_count = 3
+        failed.last_send_error = 'relay refused: 550 mailbox full'
+
+        expired, _ = invites.issue(db.session, 'expired@example.com')
+        expired.expires_at = datetime.utcnow() - timedelta(hours=1)
+
+        db.session.add(AllowedEmail(email='legacy@example.com'))
+        db.session.commit()
+
+        for row in db.session.query(AllowedEmail).all():
+            rows[row.state.value] = row.email
+    return rows
+
+
+def test_the_panel_shows_every_state_and_the_actions_that_fit_it(app, admin_client):
+    """Six states, six legible badges, and only the buttons that can do anything."""
+    states = _one_of_each_state(app)
+    assert set(states) == {'accepted', 'issued', 'sent', 'send_failed', 'expired', 'legacy'}
+
+    page = admin_client.get('/admin').get_data(as_text=True)
+
+    for label in ('accepted', 'not emailed', 'sent', 'send failed', 'expired', 'no invite'):
+        assert f'>{label}</span>' in page, f'missing badge for {label}'
+
+    # A row that has never been emailed offers "Send invite"; one that has offers
+    # "Resend". Same route, and the label is the only thing that differs.
+    assert 'Send invite' in page
+    assert 'Resend' in page
+    # Delivery trouble is visible without opening a log.
+    assert 'relay refused: 550 mailbox full' in page
+    assert '3 attempts' in page
+
+    with app.app_context():
+        accepted_id = db.session.query(AllowedEmail).filter_by(
+            email=states['accepted']).one().id
+    # An accepted invite has no live token, so neither renewal button is offered.
+    assert f'/admin/invite/{accepted_id}/resend' not in page
+    assert f'/admin/invite/{accepted_id}/link' not in page
+
+
+def test_admin_supplied_text_and_relay_errors_are_escaped(app, admin_client):
+    """Everything on this page is either admin input or a string from a remote relay."""
+    with app.app_context():
+        row = AllowedEmail(
+            email='hostile@example.com',
+            note='<script>alert(1)</script>',
+            prefill_username='<img src=x onerror=alert(2)>',
+        )
+        row.last_send_error = '<b>550</b> "rejected"'
+        db.session.add(row)
+        db.session.commit()
+
+    page = admin_client.get('/admin').get_data(as_text=True)
+
+    assert '<script>alert(1)</script>' not in page
+    assert '&lt;script&gt;alert(1)&lt;/script&gt;' in page
+    # The attribute payload survives as text; what must not survive is the tag
+    # around it, which is the difference between displayed and executed.
+    assert '<img src=x' not in page
+    assert '&lt;img src=x onerror=alert(2)&gt;' in page
+    assert '<b>550</b>' not in page
+    assert '&lt;b&gt;550&lt;/b&gt;' in page
+
+
+# ── Authorisation ──────────────────────────────────────────────────────────
+
+#: Every route this step adds or reworks, as (path template, form data).
+INVITE_ROUTES = [
+    ('/admin/email/add', {'email': 'intruder@example.com'}),
+    ('/admin/invite/{id}/resend', {}),
+    ('/admin/invite/{id}/link', {}),
+    ('/admin/email/{id}/remove', {}),
+]
+
+
+@pytest.mark.parametrize('path,data', INVITE_ROUTES)
+def test_a_non_admin_cannot_reach_any_invite_route(app, client, mailer, path, data):
+    """The boundary that matters: these routes mint credentials and send mail.
+
+    Tested directly rather than inferred from ``@admin_required`` being present,
+    because a decorator can be dropped in a refactor and nothing else here would
+    notice — an ordinary user could then invite themselves an accomplice.
+    """
+    invite, token = make_invite(app)
+
+    response = client.post(path.format(id=invite.id), data=data)
+
+    assert response.status_code == 403
+    assert mailer.outbox == []
+    # Nothing moved: no new row, and the existing token neither rotated nor died.
+    with app.app_context():
+        assert db.session.query(AllowedEmail).filter_by(
+            email='intruder@example.com').count() == 0
+    assert validates(app, token) == ADDRESS
+
+
+@pytest.mark.parametrize('path,data', INVITE_ROUTES)
+def test_an_anonymous_caller_cannot_reach_any_invite_route(
+        app, anon_client, mailer, path, data):
+    """Logged out gets the login page, not an invite."""
+    invite, token = make_invite(app)
+
+    response = anon_client.post(path.format(id=invite.id), data=data)
+
+    assert response.status_code == 302
+    assert '/login' in response.headers['Location']
+    assert mailer.outbox == []
+    with app.app_context():
+        assert db.session.query(AllowedEmail).filter_by(
+            email='intruder@example.com').count() == 0
+    assert validates(app, token) == ADDRESS
+
+
+def test_an_unknown_invite_id_is_a_404_not_a_500(app, admin_client, mailer):
+    """Both new routes take an id straight off the URL."""
+    assert admin_client.post('/admin/invite/9999/resend').status_code == 404
+    assert admin_client.post('/admin/invite/9999/link').status_code == 404
+
+
+# ── Rate limits (design §10) ───────────────────────────────────────────────
+
+#: Both new admin routes are 30/hour, keyed on the user by ``rate_limit_key``.
+INVITE_ACTION_BUDGET = 30
+
+
+def test_resend_is_capped_at_thirty_an_hour(app, admin_client, mailer):
+    """A resend button is a mail-send button pointed at a third party.
+
+    The cooldown bounds how *often* one invite can be mailed; this bounds how many
+    times the button can be pressed at all, across every row, from one account.
+    """
+    invite, _ = make_invite(app, last_sent_at=cooled_down())
+
+    statuses = [admin_client.post(f'/admin/invite/{invite.id}/resend').status_code
+                for _ in range(INVITE_ACTION_BUDGET + 1)]
+
+    assert statuses[INVITE_ACTION_BUDGET - 1] == 302
+    assert statuses[INVITE_ACTION_BUDGET] == 429
+
+
+def test_copy_link_is_capped_at_thirty_an_hour(app, admin_client, mailer):
+    """Sends no mail, but every press mints a credential and revokes the last one."""
+    invite, _ = make_invite(app)
+
+    statuses = [admin_client.post(f'/admin/invite/{invite.id}/link').status_code
+                for _ in range(INVITE_ACTION_BUDGET + 1)]
+
+    assert statuses[INVITE_ACTION_BUDGET - 1] == 302
+    assert statuses[INVITE_ACTION_BUDGET] == 429
+
+
+def test_the_limits_are_per_user_not_global(app, admin_client, mailer):
+    """One admin exhausting their budget must not lock the other admins out.
+
+    ``rate_limit_key`` buckets on the user id for authenticated routes, so this is
+    really a check that these two routes did not opt into an IP key by accident —
+    every admin in a self-hosted deployment shares an office IP.
+    """
+    invite, _ = make_invite(app, last_sent_at=cooled_down())
+    for _ in range(INVITE_ACTION_BUDGET + 1):
+        admin_client.post(f'/admin/invite/{invite.id}/resend')
+
+    with app.app_context():
+        second_admin = _make_user('root2', 'root2@example.com', is_admin=True)
+    other = app.test_client()
+    login(other, second_admin)
+
+    assert other.post(f'/admin/invite/{invite.id}/link').status_code == 302

--- a/tests/test_invite_email.py
+++ b/tests/test_invite_email.py
@@ -1,0 +1,345 @@
+"""What an invitee actually receives — ``pixelvault.emails``.
+
+The module under test is the only one that knows an invite has wording, so these
+tests read the message the way a mail client would: part order, headers, and the
+bytes of each body. Three of them are not about copy at all and are the reason
+this file exists:
+
+* **The text part must come first.** ``multipart/alternative`` means the client
+  picks the *last* part it can render, so ordering is the mechanism that makes the
+  HTML disposable. If a future edit swaps the two calls, the guaranteed-readable
+  copy becomes the fallback for a client that cannot read HTML — and nothing else
+  in the suite would notice.
+* **The link's origin comes from configuration, never from the request.** One test
+  builds the message inside a request context carrying a hostile ``Host`` header
+  and asserts the link still points at ``TEST_PUBLIC_BASE_URL``. That is the whole
+  point of design §6, and it is only observable here.
+* **The token never reaches a log record**, on the success path *and* the failure
+  path — the failure path being the one whose output ends up in a bug report.
+
+Configuration comes from ``_TEST_ENV`` in ``conftest.py``, read at import time:
+``TEST_PUBLIC_BASE_URL`` is the origin every link below is checked against, and
+``TEST_INVITE_TTL_HOURS`` is 72, which is why the expiry reads "about 3 days".
+"""
+
+import logging
+
+import pytest
+
+from pixelvault import emails, invites
+from pixelvault.extensions import db, mailer as mailer_proxy
+from pixelvault.mailer import MailError, Mailer
+from pixelvault.models import InviteState
+
+from tests.conftest import TEST_MAIL_FROM, TEST_PUBLIC_BASE_URL
+
+
+@pytest.fixture
+def session(app):
+    """The ORM session, with an app context — ``render_template`` needs one too."""
+    with app.app_context():
+        yield db.session
+
+
+@pytest.fixture
+def invite_and_token(session):
+    """A freshly issued invite and its plaintext token, exactly as a route holds them."""
+    return invites.issue(session, "invitee@example.com")
+
+
+class ExplodingMailer(Mailer):
+    """A transport that always refuses, the way a relay rejecting the envelope does.
+
+    Its message deliberately looks like a real SMTP complaint: ``last_send_error``
+    is rendered back to the admin, so the assertion that it is stored verbatim is
+    an assertion about what the panel will say.
+    """
+
+    message = "SMTP delivery failed via smtp.example.com:587: [Errno 111] Connection refused"
+
+    def send(self, message):
+        raise MailError(self.message)
+
+
+def parts_of(message):
+    """Return the message's parts in wire order, as (content_type, body) pairs."""
+    return [(part.get_content_type(), part.get_content()) for part in message.iter_parts()]
+
+
+# ── Structure ──────────────────────────────────────────────────────────────
+
+def test_message_is_multipart_alternative_with_text_first(invite_and_token):
+    """Part order is the contract: the HTML is allowed to be broken, the text is not."""
+    invite, token = invite_and_token
+
+    message = emails.build_invite_email(invite, token)
+
+    assert message.get_content_type() == 'multipart/alternative'
+    assert [content_type for content_type, _ in parts_of(message)] == ['text/plain', 'text/html']
+
+
+def test_both_parts_carry_the_invite_url(invite_and_token):
+    """A part without the link is a part that cannot complete the invite."""
+    invite, token = invite_and_token
+    expected = f"{TEST_PUBLIC_BASE_URL}/invite/{token}"
+
+    message = emails.build_invite_email(invite, token)
+
+    for content_type, body in parts_of(message):
+        assert expected in body, f"{content_type} part is missing the invite link"
+
+
+def test_html_part_shows_the_url_as_text_not_only_as_a_link(invite_and_token):
+    """Some clients and gateways rewrite or strip anchors; the plain URL survives that.
+
+    Asserted by finding the URL *outside* an ``href`` — i.e. as visible body text —
+    because an occurrence only inside the button's attribute would not be readable
+    once the anchor is mangled.
+    """
+    invite, token = invite_and_token
+    expected = f"{TEST_PUBLIC_BASE_URL}/invite/{token}"
+
+    message = emails.build_invite_email(invite, token)
+    html = dict(parts_of(message))['text/html']
+
+    assert f">{expected}<" in html
+
+
+# ── Where the link points ──────────────────────────────────────────────────
+
+def test_url_is_base_url_plus_invite_path(invite_and_token):
+    """Exactly ``<base_url>/invite/<token>`` — the path the acceptance route claims."""
+    invite, token = invite_and_token
+
+    message = emails.build_invite_email(invite, token)
+    text = dict(parts_of(message))['text/plain']
+
+    assert f"{TEST_PUBLIC_BASE_URL}/invite/{token}" in text
+
+
+def test_base_url_argument_is_the_only_origin(invite_and_token):
+    """Passing a different origin moves the link, so nothing else is contributing one."""
+    invite, token = invite_and_token
+
+    message = emails.build_invite_email(invite, token, base_url="https://elsewhere.example")
+    text = dict(parts_of(message))['text/plain']
+
+    assert f"https://elsewhere.example/invite/{token}" in text
+    assert TEST_PUBLIC_BASE_URL not in text
+
+
+def test_a_hostile_host_header_cannot_steer_the_link(app, invite_and_token):
+    """The attack design §6 exists to close, asserted rather than argued.
+
+    An admin adding an email is an ordinary HTTP request, and behind
+    Cloudflare -> nginx the ``Host`` on it is attacker-supplied. Were the link
+    reconstructed from the request — ``url_for(_external=True)`` — this message
+    would invite a real person to a domain the attacker controls, from a genuine
+    sending address. Building from configuration is what makes the header inert.
+    """
+    invite, token = invite_and_token
+
+    with app.test_request_context('/admin/email/add',
+                                  headers={'Host': 'phish.example'},
+                                  base_url='https://phish.example'):
+        message = emails.build_invite_email(invite, token)
+
+    for _, body in parts_of(message):
+        assert 'phish.example' not in body
+        assert f"{TEST_PUBLIC_BASE_URL}/invite/{token}" in body
+
+
+def test_no_expiry_on_the_row_is_refused(session, invite_and_token):
+    """A link that cannot say when it dies is the silent failure this email prevents."""
+    invite, token = invite_and_token
+    invite.expires_at = None
+
+    with pytest.raises(ValueError):
+        emails.build_invite_email(invite, token)
+
+
+# ── Headers a client will show ─────────────────────────────────────────────
+
+def test_headers_are_what_the_client_displays(invite_and_token):
+    invite, token = invite_and_token
+
+    message = emails.build_invite_email(invite, token)
+
+    assert message['To'] == 'invitee@example.com'
+    assert message['From'] == f"PixelVault <{TEST_MAIL_FROM}>"
+    assert message['Subject'] == 'You have been invited to PixelVault'
+
+
+def test_date_and_message_id_are_present(invite_and_token):
+    """Both are absent-header spam signals, and an invite must not land in spam.
+
+    The Message-ID's domain is the sender's rather than the host's own name, which
+    ``make_msgid()`` would otherwise leak into every recipient's mailbox.
+    """
+    invite, token = invite_and_token
+
+    message = emails.build_invite_email(invite, token)
+
+    assert message['Date']
+    assert message['Message-ID'].endswith(f"@{TEST_MAIL_FROM.split('@')[1]}>")
+
+
+# ── The copy itself ────────────────────────────────────────────────────────
+
+def test_expiry_is_stated_in_both_parts(invite_and_token):
+    """An invite that silently stops working is the support ticket this feature prevents.
+
+    Both halves are asserted: the absolute instant, labelled UTC because an
+    unlabelled time is wrong rather than merely vague for a reader in another zone,
+    and the coarse "about 3 days" that is the part people actually read. Three days
+    because ``TEST_INVITE_TTL_HOURS`` is 72.
+    """
+    invite, token = invite_and_token
+    expires_at = invite.expires_at
+
+    message = emails.build_invite_email(invite, token)
+
+    for content_type, body in parts_of(message):
+        assert f"{expires_at.day} {expires_at:%B %Y}" in body, content_type
+        assert f"{expires_at:%H:%M} UTC" in body, content_type
+        assert 'about 3 days from now' in body, content_type
+
+
+def test_copy_states_the_invite_is_single_use_and_bound_to_the_address(invite_and_token):
+    """Two facts an invitee needs before clicking, in both parts."""
+    invite, token = invite_and_token
+
+    message = emails.build_invite_email(invite, token)
+
+    for content_type, body in parts_of(message):
+        assert 'once' in body, content_type
+        assert 'invitee@example.com' in body, content_type
+
+
+def test_a_suggested_username_is_mentioned_only_when_there_is_one(session):
+    """``prefill_username`` is optional; an empty one must not leave a dangling sentence."""
+    with_name, token = invites.issue(session, "named@example.com", prefill_username="jamie")
+    without_name, other_token = invites.issue(session, "plain@example.com")
+
+    named = dict(parts_of(emails.build_invite_email(with_name, token)))
+    plain = dict(parts_of(emails.build_invite_email(without_name, other_token)))
+
+    assert 'jamie' in named['text/plain'] and 'jamie' in named['text/html']
+    assert 'suggested' not in plain['text/plain']
+    assert 'suggested' not in plain['text/html']
+
+
+def test_html_carries_no_remote_assets_or_script(invite_and_token):
+    """Images, web fonts and script are blocked, stripped, or both — so there are none."""
+    invite, token = invite_and_token
+
+    html = dict(parts_of(emails.build_invite_email(invite, token)))['text/html']
+
+    assert '<img' not in html
+    assert '<script' not in html
+    assert '<style' not in html          # Gmail strips these; every rule is inline instead
+    assert 'src=' not in html
+    assert 'fonts.googleapis.com' not in html
+
+
+# ── send_invite: the row is stamped either way ─────────────────────────────
+
+def test_send_invite_sends_through_the_configured_backend(session, mailer, invite_and_token):
+    """Routes will hand it the ``extensions.mailer`` proxy; that path is the one tested."""
+    invite, token = invite_and_token
+
+    emails.send_invite(mailer_proxy, session, invite, token)
+
+    assert len(mailer.outbox) == 1
+    assert mailer.outbox[0]['To'] == 'invitee@example.com'
+
+
+def test_success_stamps_the_row_and_clears_a_previous_failure(session, mailer, invite_and_token):
+    """A resend that works must move the row out of SEND_FAILED.
+
+    Without the clear, one bad relay day leaves the panel telling the admin to keep
+    retrying a delivery that already succeeded.
+    """
+    invite, token = invite_and_token
+    invites.mark_sent(session, invite, error="550 5.1.1 user unknown")
+    assert invite.state is InviteState.SEND_FAILED
+    before = invite.send_count
+
+    emails.send_invite(mailer, session, invite, token)
+
+    assert invite.last_sent_at is not None
+    assert invite.send_count == before + 1
+    assert invite.last_send_error == ''
+    assert invite.state is InviteState.SENT
+
+
+def test_failure_records_the_error_bumps_the_count_and_re_raises(session, invite_and_token):
+    """``mark_sent`` runs on the failure path too — design §13 calls this out by name.
+
+    Skipping it there would leave ``send_count`` undercounting *and* leave
+    ``last_send_error`` empty, so a message that never left the process would read
+    as SENT in the admin panel: the failure mode is an invitee waiting for mail
+    nobody can see was lost.
+    """
+    invite, token = invite_and_token
+    before = invite.send_count
+
+    with pytest.raises(MailError):
+        emails.send_invite(ExplodingMailer(), session, invite, token)
+
+    assert invite.send_count == before + 1
+    assert invite.last_sent_at is not None
+    assert invite.last_send_error == ExplodingMailer.message
+    assert invite.state is InviteState.SEND_FAILED
+
+
+def test_failure_leaves_the_token_usable(session, invite_and_token):
+    """Delivery failed; the credential did not. The copy-link fallback depends on this."""
+    invite, token = invite_and_token
+
+    with pytest.raises(MailError):
+        emails.send_invite(ExplodingMailer(), session, invite, token)
+
+    assert invites.validate(session, token).id == invite.id
+
+
+def test_a_long_relay_error_is_truncated_to_the_column(session, invite_and_token):
+    """``last_send_error`` is ``String(256)`` and SQLite would not complain until Postgres did."""
+    invite, token = invite_and_token
+
+    class Verbose(Mailer):
+        def send(self, message):
+            raise MailError('x' * 1000)
+
+    with pytest.raises(MailError):
+        emails.send_invite(Verbose(), session, invite, token)
+
+    assert len(invite.last_send_error) == invites.MAX_SEND_ERROR_LEN
+
+
+# ── The token stays out of the logs ────────────────────────────────────────
+
+def test_a_successful_send_never_logs_the_token(session, mailer, invite_and_token, caplog):
+    """The token creates an account bound to a real address; a log copy is a credential copy."""
+    invite, token = invite_and_token
+    caplog.set_level(logging.DEBUG)
+
+    emails.send_invite(mailer, session, invite, token)
+
+    assert caplog.text                      # something really was logged
+    assert token not in caplog.text
+    assert 'invitee@example.com' in caplog.text   # the address is fine, and useful
+
+
+def test_a_failed_send_never_logs_the_token_or_the_body(session, invite_and_token, caplog):
+    """The path whose output reaches a bug tracker is the one that must be cleanest."""
+    invite, token = invite_and_token
+    caplog.set_level(logging.DEBUG)
+
+    with pytest.raises(MailError) as caught:
+        emails.send_invite(ExplodingMailer(), session, invite, token)
+
+    assert caplog.text
+    assert token not in caplog.text
+    assert token not in str(caught.value)
+    assert 'Create your account' not in caplog.text   # nor any of the body

--- a/tests/test_invite_lifecycle.py
+++ b/tests/test_invite_lifecycle.py
@@ -1,0 +1,525 @@
+"""The invite lifecycle in ``pixelvault.invites`` — mint, validate, burn.
+
+These tests are deliberately HTTP-free. ``invites.py`` is plain functions over the
+ORM session precisely so the rules can be exercised without a request context, and
+testing them here rather than through a route is what keeps them honest when steps
+5 and 6 wrap them in flashes and redirects: an assertion about a status code would
+pass just as happily against a route that forgot to re-validate.
+
+Two habits from the rest of the suite carry over:
+
+* **Time moves by writing a timestamp, never by sleeping.** ``config.py`` binds the
+  TTL and the cooldown at import (see ``conftest.py``), so they are 72 hours and 60
+  seconds for the whole run and waiting one out is not an option. Every "later"
+  below is a backdated column or an explicit ``now=`` argument.
+* **The plaintext token is checked for absence, not just presence.** It is a bearer
+  credential that creates an account bound to a real person's address, so several
+  tests assert where it *isn't* — on the row, in a log line, or still working after
+  a rotation.
+"""
+
+import hashlib
+import logging
+import re
+from datetime import datetime, timedelta
+
+import pytest
+from sqlalchemy.orm import Session as SASession
+
+from pixelvault import invites
+from pixelvault.extensions import db
+from pixelvault.models import AllowedEmail, InviteState, User
+
+from tests.conftest import TEST_INVITE_COOLDOWN_SECONDS, TEST_INVITE_TTL_HOURS
+
+PASSWORD = "correct horse battery staple"
+
+
+@pytest.fixture
+def session(app):
+    """The ORM session every function under test takes as its first argument.
+
+    An app context is pushed for its lifetime because Flask-SQLAlchemy scopes
+    ``db.session`` to one, and because ``db.engine`` — needed by the race test —
+    resolves through the same context.
+    """
+    with app.app_context():
+        yield db.session
+
+
+def _issue(session, email="invitee@example.com", **kwargs):
+    return invites.issue(session, email, **kwargs)
+
+
+def _backdate(session, invite, **delta):
+    """Move an invite's clock into the past by rewriting the columns that carry it."""
+    shift = timedelta(**delta)
+    if invite.token_issued_at is not None:
+        invite.token_issued_at -= shift
+    if invite.expires_at is not None:
+        invite.expires_at -= shift
+    if invite.last_sent_at is not None:
+        invite.last_sent_at -= shift
+    session.commit()
+
+
+# ── Issuing ────────────────────────────────────────────────────────────────
+
+def test_hash_token_is_a_plain_sha256_hexdigest(app):
+    """Pinned because the column is ``String(64)`` and the model tests assume this form.
+
+    Anything else — a salted hash, a different digest, base64 — either overflows
+    the column or silently stops matching rows written by an earlier release.
+    """
+    digest = invites.hash_token("a-token")
+    assert digest == hashlib.sha256(b"a-token").hexdigest()
+    assert re.fullmatch(r"[0-9a-f]{64}", digest)
+
+
+def test_issue_returns_a_plaintext_whose_hash_is_what_the_row_stores(session):
+    """The whole point of hashing at rest: the row cannot reproduce the link.
+
+    The returned string is the only copy that will ever exist; from here it lives
+    in an email and nowhere else.
+    """
+    invite, token = _issue(session)
+
+    assert invite.token_hash == hashlib.sha256(token.encode()).hexdigest()
+    assert invite.token_hash != token
+    assert token not in (invite.email, invite.note, invite.prefill_username)
+    assert invite.state is InviteState.ISSUED
+
+
+def test_issue_stamps_the_token_its_issue_time_and_its_expiry_together(session):
+    """All three or none. ``state`` reads ``expires_at`` directly and never re-derives
+    it, so a row holding a token with a NULL expiry reports ISSUED forever — an
+    immortal credential the admin panel swears is fine."""
+    invite, _ = _issue(session)
+
+    assert invite.token_hash is not None
+    assert invite.token_issued_at is not None
+    assert invite.expires_at is not None
+    assert invite.expires_at - invite.token_issued_at == timedelta(hours=TEST_INVITE_TTL_HOURS)
+
+
+def test_issue_normalises_the_address_it_authorizes(session):
+    """The address is the whitelist key and, after acceptance, the account identity.
+
+    Storing it as typed would let one person's invite authorize a second row that
+    looks like a different address to every lookup that follows.
+    """
+    invite, _ = _issue(session, "  Invitee@Example.COM ")
+    assert invite.email == "invitee@example.com"
+
+
+def test_two_invites_never_share_a_token(session):
+    first, first_token = _issue(session, "one@example.com")
+    second, second_token = _issue(session, "two@example.com")
+
+    assert first_token != second_token
+    assert first.token_hash != second.token_hash
+
+
+def test_issuing_an_address_twice_is_refused_and_leaves_the_session_usable(session):
+    """The backstop for two admins clicking at once.
+
+    The rollback is the load-bearing half: an un-rolled-back failed flush poisons
+    every later statement on the session, so the admin request would fail on
+    something unrelated further down instead of flashing "already invited".
+    """
+    _issue(session, "dup@example.com")
+
+    with pytest.raises(invites.InviteError):
+        _issue(session, "dup@example.com")
+
+    assert session.query(AllowedEmail).count() == 1
+
+
+# ── Validation ─────────────────────────────────────────────────────────────
+
+def test_validate_returns_the_row_a_live_token_belongs_to(session):
+    invite, token = _issue(session)
+    assert invites.validate(session, token).id == invite.id
+
+
+def test_validate_rejects_a_token_no_row_holds(session):
+    _issue(session)
+    with pytest.raises(invites.InvalidInvite):
+        invites.validate(session, "not-a-real-token")
+
+
+@pytest.mark.parametrize("token", ["", None])
+def test_validate_rejects_an_absent_token_without_touching_the_database(session, token):
+    """A missing session key reaches ``validate`` as ``None``; hashing it would
+    raise ``AttributeError`` and surface as a 500 rather than as "check your link"."""
+    with pytest.raises(invites.InvalidInvite):
+        invites.validate(session, token)
+
+
+def test_validate_reports_an_elapsed_ttl_as_expired_not_invalid(session):
+    """The two need opposite advice — "ask for a new link" versus "check the one you have"."""
+    invite, token = _issue(session)
+    _backdate(session, invite, hours=TEST_INVITE_TTL_HOURS + 1)
+
+    with pytest.raises(invites.ExpiredInvite):
+        invites.validate(session, token)
+
+
+def test_expiry_is_inclusive_of_the_boundary(session):
+    """At exactly ``expires_at`` the link is already dead, matching ``AllowedEmail.state``.
+
+    A strict ``>`` here would open a window in which the admin panel says EXPIRED
+    and the link still works — the one disagreement between the two views that
+    nobody could diagnose from the outside.
+    """
+    invite, token = _issue(session)
+    deadline = invite.expires_at
+
+    assert invites.validate(session, token, now=deadline - timedelta(microseconds=1))
+
+    with pytest.raises(invites.ExpiredInvite):
+        invites.validate(session, token, now=deadline)
+
+
+def test_validate_refuses_a_token_with_no_expiry_at_all(session):
+    """A row ``_mint`` never writes, so it is corruption or a hand-edited database.
+
+    Fail closed: honouring it would mean a bearer credential that never dies, which
+    is a worse outcome than refusing a row that should not exist.
+    """
+    invite, token = _issue(session)
+    invite.expires_at = None
+    session.commit()
+
+    with pytest.raises(invites.ExpiredInvite):
+        invites.validate(session, token)
+
+
+def test_validate_reports_an_accepted_invite_as_accepted(session):
+    """Acceptance is checked before expiry, in the same order as ``AllowedEmail.state``.
+
+    The row is stamped by hand because the honest path cannot produce it: ``consume``
+    nulls ``token_hash`` in the same transaction, so a replayed link takes the
+    branch in the next test instead. This one pins the precedence, so an admin who
+    clears an account's ``token_hash`` by hand — or a future path that stamps
+    acceptance without burning the token — still gets "you already registered"
+    rather than an expiry message about a row nobody can renew.
+    """
+    invite, token = _issue(session)
+    invite.accepted_at = datetime.utcnow()
+    invite.expires_at = datetime.utcnow() - timedelta(hours=1)
+    session.commit()
+
+    with pytest.raises(invites.AlreadyAccepted):
+        invites.validate(session, token)
+
+
+def test_a_consumed_link_stops_validating_entirely(session):
+    """Documents the accepted cost of nulling the hash: a used link is indistinguishable
+    from a typo, because there is nothing left on any row to match it against. The
+    acceptance page in step 6 has to word ``InvalidInvite`` for both audiences."""
+    invite, token = _issue(session)
+    invites.consume(session, invite, username="invitee", password=PASSWORD)
+
+    with pytest.raises(invites.InvalidInvite):
+        invites.validate(session, token)
+
+
+# ── Rotation ───────────────────────────────────────────────────────────────
+
+def test_rotate_returns_a_different_token_and_kills_the_previous_link(session):
+    """The consequence of hashing, and the safer default: a resend usually means the
+    first link was lost or went somewhere it should not have."""
+    invite, old_token = _issue(session)
+    new_token = invites.rotate(session, invite)
+
+    assert new_token != old_token
+    assert invites.validate(session, new_token).id == invite.id
+    with pytest.raises(invites.InvalidInvite):
+        invites.validate(session, old_token)
+
+
+def test_rotate_restarts_the_ttl_so_an_expired_invite_becomes_usable(session):
+    """The EXPIRED -> resend path. Without a fresh expiry the new link would be born dead."""
+    invite, _ = _issue(session)
+    _backdate(session, invite, hours=TEST_INVITE_TTL_HOURS + 1)
+    assert invite.state is InviteState.EXPIRED
+
+    token = invites.rotate(session, invite)
+
+    assert invites.validate(session, token).id == invite.id
+    assert invite.expires_at > datetime.utcnow()
+
+
+def test_rotate_issues_a_first_token_to_a_legacy_row(session):
+    """The *Send invite* button on a whitelist entry that predates the feature.
+
+    Those rows have no token and, once registration is link-only, no way in at all
+    until an admin clicks. ``rotate`` is that click — there is no separate "issue on
+    an existing row" path to get wrong.
+    """
+    legacy = AllowedEmail(email="old@example.com")
+    session.add(legacy)
+    session.commit()
+    assert legacy.state is InviteState.LEGACY
+
+    token = invites.rotate(session, legacy)
+
+    assert legacy.state is InviteState.ISSUED
+    assert invites.validate(session, token).id == legacy.id
+
+
+def test_rotate_preserves_the_send_history(session):
+    """``send_count`` is what tells an admin "resent 4x, still not accepted", and the
+    recorded error stays true until another delivery is actually attempted."""
+    invite, _ = _issue(session)
+    invites.mark_sent(session, invite, error="450 mailbox unavailable")
+
+    invites.rotate(session, invite)
+
+    assert invite.send_count == 1
+    assert invite.last_send_error == "450 mailbox unavailable"
+
+
+def test_rotate_refuses_an_accepted_invite(session):
+    """Acceptance is terminal. Re-minting here would hang a live credential off a
+    finished row and put a *Resend* button in front of someone who already logs in."""
+    invite, _ = _issue(session)
+    invites.consume(session, invite, username="invitee", password=PASSWORD)
+
+    with pytest.raises(invites.AlreadyAccepted):
+        invites.rotate(session, invite)
+
+    assert invite.token_hash is None
+
+
+# ── Acceptance ─────────────────────────────────────────────────────────────
+
+def test_consume_creates_a_working_account_with_the_email_from_the_invite_row(session):
+    """The highest-value assertion in the feature.
+
+    The address comes off the server-side row and is not a parameter at all, so
+    there is no form field a holder of an invite for one address could use to
+    register as another. The password is checked through ``check_password`` rather
+    than by inspecting the hash, because ``consume`` must go through
+    ``User.set_password`` and not hand-roll the hashing parameters.
+    """
+    invite, _ = _issue(session, "invitee@example.com")
+
+    user = invites.consume(session, invite, username="invitee", password=PASSWORD)
+
+    assert user.email == "invitee@example.com"
+    assert user.username == "invitee"
+    assert user.check_password(PASSWORD)
+    assert user.is_admin is False
+
+
+def test_consume_burns_the_invite_in_the_same_breath(session):
+    """Acceptance stamped, token nulled, the account linked back — all committed once.
+
+    Split across two transactions, a crash between them leaves either an account
+    beside a still-live link that can be replayed, or a burnt invite with no account
+    and an invitee locked out with nothing to click.
+    """
+    invite, _ = _issue(session)
+
+    user = invites.consume(session, invite, username="invitee", password=PASSWORD)
+
+    assert invite.accepted_at is not None
+    assert invite.accepted_user_id == user.id
+    assert invite.token_hash is None
+    assert invite.state is InviteState.ACCEPTED
+    assert invite.is_pending is False
+
+
+def test_an_invite_can_only_be_consumed_once(session):
+    invite, _ = _issue(session)
+    invites.consume(session, invite, username="invitee", password=PASSWORD)
+
+    with pytest.raises(invites.AlreadyAccepted):
+        invites.consume(session, invite, username="invitee-again", password=PASSWORD)
+
+    assert session.query(User).count() == 1
+
+
+def test_consume_refuses_an_expired_invite_even_if_validate_was_skipped(session):
+    """``consume`` re-checks rather than trusting the caller's earlier verdict: the
+    GET that validated the link and the POST that accepts it are separate requests,
+    and the TTL can lapse between them."""
+    invite, _ = _issue(session)
+    _backdate(session, invite, hours=TEST_INVITE_TTL_HOURS + 1)
+
+    with pytest.raises(invites.ExpiredInvite):
+        invites.consume(session, invite, username="invitee", password=PASSWORD)
+
+    assert session.query(User).count() == 0
+
+
+def test_two_consumes_racing_on_one_invite_produce_exactly_one_user(session, app):
+    """A double-submit, or a link forwarded to a second person, must lose cleanly.
+
+    The loser is driven from its own ORM session holding a copy of the row read
+    *before* the winner committed — which is exactly what a second browser tab has.
+    Its in-memory ``accepted_at`` is still None, so it sails past the guard and is
+    stopped by the database instead: both consumes necessarily agree on the email,
+    because the email comes from the invite, so the unique index on ``user.email``
+    refuses the second insert whatever username it picked.
+    """
+    invite, _ = _issue(session, "race@example.com")
+    invite_id = invite.id
+
+    with SASession(bind=db.engine) as loser_session:
+        stale = loser_session.get(AllowedEmail, invite_id)
+        assert stale.accepted_at is None
+
+        winner = invites.consume(session, invite, username="winner", password=PASSWORD)
+
+        with pytest.raises(invites.AlreadyAccepted):
+            invites.consume(loser_session, stale, username="loser", password=PASSWORD)
+
+    users = session.query(User).all()
+    assert [u.username for u in users] == ["winner"]
+    assert invite.accepted_user_id == winner.id
+
+
+def test_a_username_collision_is_not_reported_as_an_accepted_invite(session):
+    """Both faults surface as an IntegrityError and need opposite advice — "sign in"
+    versus "pick another name" — so ``consume`` re-reads the row to tell them apart."""
+    session.add(User(username="taken", email="someone@example.com",
+                     password_hash="pbkdf2:sha256:600000$test$deadbeef"))
+    session.commit()
+    invite, _ = _issue(session)
+
+    with pytest.raises(invites.InviteError) as caught:
+        invites.consume(session, invite, username="taken", password=PASSWORD)
+
+    assert not isinstance(caught.value, invites.AlreadyAccepted)
+    assert invite.accepted_at is None
+    assert invite.token_hash is not None  # the link still works; only the name was bad
+
+
+# ── Delivery bookkeeping ───────────────────────────────────────────────────
+
+def test_mark_sent_records_a_successful_send(session):
+    invite, _ = _issue(session)
+
+    invites.mark_sent(session, invite)
+
+    assert invite.send_count == 1
+    assert invite.last_sent_at is not None
+    assert invite.last_send_error == ""
+    assert invite.state is InviteState.SENT
+
+
+def test_a_successful_send_clears_a_previous_failure(session):
+    """Otherwise a row that failed once reads SEND_FAILED forever, and the panel keeps
+    telling the admin to retry a delivery that has already worked."""
+    invite, _ = _issue(session)
+    invites.mark_sent(session, invite, error="SMTPAuthenticationError: 535")
+    assert invite.state is InviteState.SEND_FAILED
+
+    invites.mark_sent(session, invite)
+
+    assert invite.state is InviteState.SENT
+    assert invite.last_send_error == ""
+    assert invite.send_count == 2  # attempts, not successes
+
+
+def test_a_failed_send_is_counted_and_its_error_truncated_to_the_column(session):
+    """The attempt counts because a failed one is exactly the attempt worth counting,
+    and SQLite would happily store an over-long relay complaint that then breaks on a
+    backend which enforces VARCHAR length."""
+    invite, _ = _issue(session)
+
+    invites.mark_sent(session, invite, error="x" * 4000)
+
+    assert len(invite.last_send_error) == invites.MAX_SEND_ERROR_LEN
+    assert invite.send_count == 1
+    assert invite.last_sent_at is not None
+    assert invite.state is InviteState.SEND_FAILED
+
+
+def test_mark_sent_survives_a_round_trip(session):
+    """The stamps have to persist, not just live on the instance the caller holds."""
+    invite, _ = _issue(session)
+    invites.mark_sent(session, invite, error="boom")
+    invite_id = invite.id
+    session.expunge_all()
+
+    reloaded = session.get(AllowedEmail, invite_id)
+    assert reloaded.send_count == 1
+    assert reloaded.last_send_error == "boom"
+
+
+# ── Resend cooldown ────────────────────────────────────────────────────────
+
+def test_a_never_sent_invite_may_always_be_sent(session):
+    """Covers the first send after a copy-link handover and *Send invite* on a LEGACY
+    row — neither should be refused by a cooldown that has nothing to measure from."""
+    invite, _ = _issue(session)
+    invites.check_resend_allowed(invite)  # must not raise
+
+
+def test_a_second_send_inside_the_cooldown_is_refused(session):
+    """The cooldown is not about admin patience: this is mail the server sends to a
+    third party on request, so an unthrottled button is a mail-bomb primitive."""
+    invite, _ = _issue(session)
+    invites.mark_sent(session, invite)
+
+    with pytest.raises(invites.ResendTooSoon) as caught:
+        invites.check_resend_allowed(invite)
+
+    assert 0 < caught.value.seconds_remaining <= TEST_INVITE_COOLDOWN_SECONDS
+
+
+def test_the_refusal_says_how_long_is_left(session):
+    """So the route can say "try again in 40 seconds" instead of an unqualified no."""
+    invite, _ = _issue(session)
+    invites.mark_sent(session, invite)
+    _backdate(session, invite, seconds=TEST_INVITE_COOLDOWN_SECONDS - 40)
+
+    with pytest.raises(invites.ResendTooSoon) as caught:
+        invites.check_resend_allowed(invite)
+
+    assert caught.value.seconds_remaining == 40
+
+
+def test_the_cooldown_lapses(session):
+    invite, _ = _issue(session)
+    invites.mark_sent(session, invite)
+    _backdate(session, invite, seconds=TEST_INVITE_COOLDOWN_SECONDS + 1)
+
+    invites.check_resend_allowed(invite)  # must not raise
+
+
+def test_the_cooldown_boundary_permits_the_send(session):
+    """At exactly the cooldown nothing is remaining, so refusing would leave a button
+    that says "wait 0 seconds" and then refuses again."""
+    invite, _ = _issue(session)
+    invites.mark_sent(session, invite)
+    now = invite.last_sent_at + timedelta(seconds=TEST_INVITE_COOLDOWN_SECONDS)
+
+    invites.check_resend_allowed(invite, now=now)  # must not raise
+
+
+# ── The token never escapes ────────────────────────────────────────────────
+
+def test_no_lifecycle_call_ever_logs_the_token(session, caplog):
+    """The invariant the module's docstring opens with, asserted rather than asserted-to.
+
+    A token in a log file is a copy of a credential that creates an account bound to
+    someone's email address — and logs are the one place secrets travel furthest,
+    into aggregators and crash reports. Log lines may name the invite or the address;
+    never the secret.
+    """
+    caplog.set_level(logging.DEBUG, logger="pixelvault.invites")
+
+    invite, first_token = _issue(session, "quiet@example.com")
+    second_token = invites.rotate(session, invite)
+    invites.mark_sent(session, invite, error="550 5.1.1 user unknown")
+    invites.mark_sent(session, invite)
+    invites.consume(session, invite, username="quiet", password=PASSWORD)
+
+    assert caplog.text  # the calls above really did log something
+    assert first_token not in caplog.text
+    assert second_token not in caplog.text

--- a/tests/test_invite_model.py
+++ b/tests/test_invite_model.py
@@ -1,0 +1,319 @@
+"""The invite state machine on ``AllowedEmail``.
+
+``state`` is a derived property, not a column, so these tests are about one thing:
+that six mutually exclusive situations each map to the right name, and that the
+*order* the branches are tried in survives edits. Precedence is the part worth
+testing, because every pair below is a row where two branches are simultaneously
+true and only the earlier one may win — an accepted invite whose TTL has since
+lapsed is still ACCEPTED, a row with a delivery error is EXPIRED once its token
+dies, and so on. Get the order wrong and every individual state still passes.
+
+Rows are built by hand rather than through ``invites.py``, which does not exist
+yet at this step and which these tests must not depend on either way: the model
+is the contract, and ``issue`` / ``rotate`` / ``consume`` are just three of its
+callers. The shapes assembled here are exactly the ones those functions will
+produce — see docs/invite_registration_design.md §4 and §13.
+
+Time moves by writing a timestamp, never by sleeping; the TTL is 72 hours in
+this suite (``TEST_INVITE_TTL_HOURS``), so waiting one out is not an option.
+"""
+
+import hashlib
+from datetime import datetime, timedelta
+
+import pytest
+
+from tests.conftest import TEST_INVITE_TTL_HOURS
+
+
+def _token_hash(token="an-invite-token"):
+    """The stored form of a token: sha256 hex, as ``invites.hash_token`` will produce."""
+    return hashlib.sha256(token.encode()).hexdigest()
+
+
+def _invite(email="invitee@example.com", **overrides):
+    """An unsaved ``AllowedEmail`` in the shape ``issue()`` leaves behind.
+
+    The default is the freshly-minted invite — token live, never emailed — because
+    every other state is that row plus one or two more stamps, which is how the
+    real lifecycle reaches them too.
+    """
+    from pixelvault.models import AllowedEmail
+
+    now = datetime.utcnow()
+    fields = dict(
+        email=email,
+        note='',
+        added_at=now,
+        token_hash=_token_hash(),
+        token_issued_at=now,
+        expires_at=now + timedelta(hours=TEST_INVITE_TTL_HOURS),
+        prefill_username='',
+        last_sent_at=None,
+        send_count=0,
+        last_send_error='',
+        accepted_at=None,
+        accepted_user_id=None,
+        invited_by_id=None,
+    )
+    fields.update(overrides)
+    return AllowedEmail(**fields)
+
+
+def _past(hours=1):
+    return datetime.utcnow() - timedelta(hours=hours)
+
+
+# ── The six states ─────────────────────────────────────────────────────────
+
+def test_a_row_with_no_token_is_legacy(app):
+    """A whitelist entry that predates invites — the shape already in production.
+
+    Nothing but ``email`` is set, which is all the old schema had and all the
+    migration leaves behind. It must not read as ISSUED or SENT: an admin looking
+    at this row has to be told the address can no longer register until someone
+    issues it a link.
+    """
+    from pixelvault.models import InviteState
+
+    row = _invite(token_hash=None, token_issued_at=None, expires_at=None)
+    assert row.state is InviteState.LEGACY
+    assert row.is_pending is False
+
+
+def test_a_freshly_minted_token_that_was_never_emailed_is_issued(app):
+    """The copy-link path, and what an invite issued with MAIL_ENABLED=false looks like."""
+    from pixelvault.models import InviteState
+
+    assert _invite().state is InviteState.ISSUED
+
+
+def test_a_delivered_invite_is_sent(app):
+    from pixelvault.models import InviteState
+
+    row = _invite(last_sent_at=datetime.utcnow(), send_count=1)
+    assert row.state is InviteState.SENT
+
+
+def test_a_relay_failure_with_a_live_token_is_send_failed(app):
+    """Delivery failed, the credential did not — which is why this is still pending.
+
+    ``last_sent_at`` is stamped as well, because ``mark_sent`` records the attempt
+    whether or not the relay accepted it. So this row is simultaneously "sent" and
+    "failed", and the error must win.
+    """
+    from pixelvault.models import InviteState
+
+    row = _invite(last_sent_at=datetime.utcnow(), send_count=1,
+                  last_send_error='SMTPAuthenticationError: 535')
+    assert row.state is InviteState.SEND_FAILED
+
+
+def test_an_unclicked_token_past_its_ttl_is_expired(app):
+    from pixelvault.models import InviteState
+
+    row = _invite(expires_at=_past(), last_sent_at=_past(hours=TEST_INVITE_TTL_HOURS + 2),
+                  send_count=1)
+    assert row.state is InviteState.EXPIRED
+    assert row.is_pending is False
+
+
+def test_a_consumed_invite_is_accepted(app):
+    """The post-``consume`` shape: token nulled, acceptance stamped.
+
+    Nulling ``token_hash`` is what makes the link single-use, so this row would
+    read as LEGACY if ACCEPTED did not come first — it would offer the admin a
+    "Send invite" button for an address that already has an account.
+    """
+    from pixelvault.models import InviteState
+
+    row = _invite(token_hash=None, accepted_at=datetime.utcnow(), accepted_user_id=1)
+    assert row.state is InviteState.ACCEPTED
+    assert row.is_pending is False
+
+
+# ── Precedence between them ────────────────────────────────────────────────
+
+def test_acceptance_outranks_an_elapsed_ttl(app):
+    """``expires_at`` is not cleared on acceptance, so it keeps lapsing afterwards.
+
+    Every accepted invite eventually reaches this state — the TTL passes days
+    later while the account is in daily use. Reporting EXPIRED there would tell an
+    admin to resend an invite to someone who already has a login.
+    """
+    from pixelvault.models import InviteState
+
+    row = _invite(token_hash=None, expires_at=_past(), accepted_at=datetime.utcnow(),
+                  accepted_user_id=1)
+    assert row.state is InviteState.ACCEPTED
+
+
+def test_acceptance_outranks_a_recorded_send_failure(app):
+    """A failed send followed by a successful copy-link handover ends ACCEPTED.
+
+    ``last_send_error`` is only cleared by another send, and the copy-link path
+    never sends, so a row can be both accepted and carrying a stale error.
+    """
+    from pixelvault.models import InviteState
+
+    row = _invite(token_hash=None, last_send_error='Connection refused',
+                  accepted_at=datetime.utcnow(), accepted_user_id=1)
+    assert row.state is InviteState.ACCEPTED
+
+
+def test_a_legacy_row_is_never_reported_as_expired(app):
+    """A tokenless row with a stale ``expires_at`` — a lapsed invite that was consumed
+    by nothing and then had its token cleared. There is no live credential to
+    expire, and the fix is to issue, not to resend."""
+    from pixelvault.models import InviteState
+
+    row = _invite(token_hash=None, expires_at=_past())
+    assert row.state is InviteState.LEGACY
+
+
+def test_an_expired_token_outranks_its_delivery_error(app):
+    """Both branches are true; the dead token is the one that matters.
+
+    Retrying delivery of a link that no longer opens is wasted mail. Ranking
+    EXPIRED first points the admin at rotate-and-resend instead of resend alone.
+    """
+    from pixelvault.models import InviteState
+
+    row = _invite(expires_at=_past(), last_sent_at=_past(hours=99), send_count=2,
+                  last_send_error='450 mailbox unavailable')
+    assert row.state is InviteState.EXPIRED
+
+
+def test_a_delivery_error_outranks_a_successful_looking_send(app):
+    """Distinguishes "the relay took it" from "the relay refused it".
+
+    Without SEND_FAILED ranking above SENT, a bounced invite is indistinguishable
+    in the admin panel from one sitting in someone's inbox, and nobody resends it.
+    """
+    from pixelvault.models import InviteState
+
+    row = _invite(last_sent_at=datetime.utcnow(), send_count=3,
+                  last_send_error='550 5.1.1 user unknown')
+    assert row.state is InviteState.SEND_FAILED
+
+
+def test_expiry_is_inclusive_of_the_boundary(app):
+    """At exactly ``expires_at`` the invite is already dead, per ``now >= expires_at``.
+
+    Pinned because ``validate()`` in step 3 must refuse the same instant this
+    property calls expired; a strict ``>`` here would leave a one-tick window in
+    which the panel says EXPIRED and the link still works.
+    """
+    from pixelvault.models import InviteState
+
+    row = _invite(expires_at=datetime.utcnow() - timedelta(microseconds=1))
+    assert row.state is InviteState.EXPIRED
+
+
+# ── is_pending ─────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("overrides, expected_state, pending", [
+    ({}, "ISSUED", True),
+    ({"last_sent_at": datetime.utcnow(), "send_count": 1}, "SENT", True),
+    ({"last_send_error": "boom"}, "SEND_FAILED", True),
+    ({"expires_at": _past()}, "EXPIRED", False),
+    ({"token_hash": None, "expires_at": None}, "LEGACY", False),
+    ({"token_hash": None, "accepted_at": datetime.utcnow()}, "ACCEPTED", False),
+])
+def test_is_pending_covers_exactly_the_states_with_a_usable_token(
+        app, overrides, expected_state, pending):
+    """Pending means: a link exists, it still works, nobody has used it.
+
+    The three false cases each need a different admin action — issue, rotate, or
+    nothing at all — which is why they are grouped apart from the three that only
+    need patience.
+    """
+    from pixelvault.models import InviteState
+
+    row = _invite(**overrides)
+    assert row.state is getattr(InviteState, expected_state)
+    assert row.is_pending is pending
+
+
+# ── Derivation, not storage ────────────────────────────────────────────────
+
+def test_state_follows_the_clock_with_no_write_to_the_row(app):
+    """The whole argument for a property: SENT becomes EXPIRED unattended.
+
+    A stored column would still read SENT here, because nothing wrote to the row
+    between the two assertions — the TTL simply passed.
+    """
+    from pixelvault.models import InviteState
+
+    row = _invite(last_sent_at=datetime.utcnow(), send_count=1)
+    assert row.state is InviteState.SENT
+
+    row.expires_at = _past()
+    assert row.state is InviteState.EXPIRED
+
+
+def test_state_survives_a_round_trip_through_the_database(app):
+    """Every column the property reads must actually persist.
+
+    Building rows in memory would not catch a column missing from the table or
+    dropped by the migration; this reloads from SQLite and asks again.
+    """
+    from pixelvault.extensions import db
+    from pixelvault.models import AllowedEmail, InviteState
+
+    with app.app_context():
+        db.session.add(_invite(last_sent_at=datetime.utcnow(), send_count=2,
+                               prefill_username='invitee',
+                               last_send_error='timed out'))
+        db.session.commit()
+        db.session.expunge_all()
+
+        row = db.session.query(AllowedEmail).filter_by(email='invitee@example.com').one()
+        assert row.state is InviteState.SEND_FAILED
+        assert row.is_pending is True
+        assert row.send_count == 2
+        assert row.prefill_username == 'invitee'
+        assert row.token_hash == _token_hash()
+
+
+def test_a_row_inserted_with_only_an_email_reads_as_legacy(app):
+    """What ``POST /admin/email/add`` produced before this feature, and what the
+    migration leaves in a live database: no invite columns touched at all.
+
+    The model defaults have to land on their own — ``send_count`` at 0 and
+    ``last_send_error`` at ``''``, not NULL — or the property's truthiness tests
+    would misfire on a row nobody stamped.
+    """
+    from pixelvault.extensions import db
+    from pixelvault.models import AllowedEmail, InviteState
+
+    with app.app_context():
+        db.session.add(AllowedEmail(email='old@example.com'))
+        db.session.commit()
+        db.session.expunge_all()
+
+        row = db.session.query(AllowedEmail).filter_by(email='old@example.com').one()
+        assert row.state is InviteState.LEGACY
+        assert row.is_pending is False
+        assert row.send_count == 0
+        assert row.last_send_error == ''
+        assert row.token_hash is None
+
+
+# ── The enum itself is part of the §13 contract ────────────────────────────
+
+def test_invite_state_members_are_the_six_from_the_design(app):
+    """Pinned because step 5's admin panel and its templates key off these names."""
+    from pixelvault.models import InviteState
+
+    assert {s.name for s in InviteState} == {
+        'ACCEPTED', 'LEGACY', 'EXPIRED', 'SEND_FAILED', 'ISSUED', 'SENT',
+    }
+
+
+def test_invite_state_is_a_string_enum(app):
+    """So a Jinja template can compare a state to a plain string without ``.value``."""
+    from pixelvault.models import InviteState
+
+    assert isinstance(InviteState.SENT, str)
+    assert InviteState.SENT == 'sent'

--- a/tests/test_mailer.py
+++ b/tests/test_mailer.py
@@ -1,0 +1,328 @@
+"""Transport-level tests for ``src/pixelvault/mailer.py``.
+
+**No test here opens a socket.** ``smtplib.SMTP`` and ``smtplib.SMTP_SSL`` are
+replaced with a recorder that captures the arguments the real class would have
+been constructed with, which is what makes the timeout assertion possible at all:
+the timeout is a constructor argument, so the only place to observe it is the
+constructor. A test that actually connected could only observe it by hanging.
+
+Configuration comes from ``_TEST_ENV`` in ``conftest.py`` (read at import time —
+see that module's docstring). The selection tests are the one exception: they
+rebind the constants on ``pixelvault.mailer`` itself, which is legitimate because
+``build_mailer`` reads them as module globals *at call time*, not as defaults
+bound at ``def``.
+"""
+
+import smtplib
+
+import pytest
+
+import pixelvault
+from pixelvault import mailer as mailer_module
+from pixelvault.mailer import (
+    ConsoleMailer,
+    MailError,
+    MemoryMailer,
+    NullMailer,
+    SMTPMailer,
+    build_mailer,
+)
+
+from .conftest import TEST_MAIL_TIMEOUT_SECONDS
+
+
+def make_message(to="invitee@example.com", subject="You have been invited to PixelVault",
+                 text="Open https://vault.test.invalid/invite/SECRET-TOKEN",
+                 html="<p>Open <a href='https://vault.test.invalid/invite/SECRET-TOKEN'>here</a></p>"):
+    """A two-part invite-shaped message, so assertions match what emails.py will send."""
+    from email.message import EmailMessage
+
+    message = EmailMessage()
+    message['To'] = to
+    message['From'] = 'pixelvault@test.invalid'
+    message['Subject'] = subject
+    message.set_content(text)
+    message.add_alternative(html, subtype='html')
+    return message
+
+
+class RecordingSMTP:
+    """Stand-in for ``smtplib.SMTP`` that records the conversation instead of having one."""
+
+    instances = []
+
+    def __init__(self, host=None, port=None, timeout=None, context=None):
+        self.host, self.port, self.timeout, self.context = host, port, timeout, context
+        self.started_tls = False
+        self.login_args = None
+        self.sent = []
+        RecordingSMTP.instances.append(self)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def starttls(self, context=None):
+        self.started_tls = True
+
+    def ehlo(self):
+        pass
+
+    def login(self, username, password):
+        self.login_args = (username, password)
+
+    def send_message(self, message):
+        self.sent.append(message)
+
+
+@pytest.fixture
+def recording_smtp(monkeypatch):
+    """Replace both smtplib entry points with :class:`RecordingSMTP` and hand back the class."""
+    RecordingSMTP.instances = []
+    monkeypatch.setattr(smtplib, 'SMTP', RecordingSMTP)
+    monkeypatch.setattr(smtplib, 'SMTP_SSL', RecordingSMTP)
+    return RecordingSMTP
+
+
+# ── build_mailer() selection ───────────────────────────────────────────────
+
+def test_build_mailer_defaults_to_console_without_smtp_host(monkeypatch):
+    """No relay configured is a working dev checkout, not an error."""
+    monkeypatch.setattr(mailer_module, 'MAIL_ENABLED', True)
+    monkeypatch.setattr(mailer_module, 'SMTP_HOST', '')
+    assert isinstance(build_mailer(), ConsoleMailer)
+
+
+def test_build_mailer_uses_smtp_when_host_is_set(monkeypatch):
+    monkeypatch.setattr(mailer_module, 'MAIL_ENABLED', True)
+    monkeypatch.setattr(mailer_module, 'SMTP_HOST', 'smtp.example.com')
+    monkeypatch.setattr(mailer_module, 'SMTP_PORT', 465)
+    monkeypatch.setattr(mailer_module, 'SMTP_SECURITY', 'ssl')
+
+    backend = build_mailer()
+
+    assert isinstance(backend, SMTPMailer)
+    assert (backend.host, backend.port, backend.security) == ('smtp.example.com', 465, 'ssl')
+
+
+def test_mail_disabled_beats_a_configured_relay(monkeypatch):
+    """MAIL_ENABLED=false is an instruction, so it must outrank leftover SMTP settings.
+
+    The realistic case is an operator who turns sending off on a host whose .env
+    still carries working credentials; if host-set won, the switch would do nothing.
+    """
+    monkeypatch.setattr(mailer_module, 'MAIL_ENABLED', False)
+    monkeypatch.setattr(mailer_module, 'SMTP_HOST', 'smtp.example.com')
+    assert isinstance(build_mailer(), NullMailer)
+
+
+def test_smtp_mailer_rejects_an_unknown_security_mode():
+    with pytest.raises(ValueError):
+        SMTPMailer('smtp.example.com', security='tls-ish')
+
+
+# ── SMTPMailer behaviour ───────────────────────────────────────────────────
+
+def test_timeout_reaches_the_socket(recording_smtp):
+    """The configured timeout must land on the connection, not just sit in config.
+
+    This is the assertion that keeps a hung relay from pinning one of only eight
+    Gunicorn threads: without the argument, smtplib blocks on the OS default,
+    which is effectively forever.
+    """
+    SMTPMailer('smtp.example.com', port=587, timeout=TEST_MAIL_TIMEOUT_SECONDS).send(make_message())
+
+    assert recording_smtp.instances[0].timeout == TEST_MAIL_TIMEOUT_SECONDS
+
+
+def test_starttls_upgrades_before_authenticating(recording_smtp, monkeypatch):
+    """Credentials must never cross a plaintext socket."""
+    calls = []
+    monkeypatch.setattr(recording_smtp, 'starttls', lambda self, context=None: calls.append('starttls'))
+    monkeypatch.setattr(recording_smtp, 'login', lambda self, u, p: calls.append('login'))
+
+    SMTPMailer('smtp.example.com', username='bot', password='pw', security='starttls').send(make_message())
+
+    assert calls == ['starttls', 'login']
+
+
+def test_ssl_mode_skips_starttls(recording_smtp):
+    """Implicit TLS is encrypted from the first byte; there is nothing to upgrade."""
+    SMTPMailer('smtp.example.com', port=465, security='ssl').send(make_message())
+
+    assert recording_smtp.instances[0].started_tls is False
+
+
+def test_no_login_without_credentials(recording_smtp):
+    """A blank username means an unauthenticated relay, not an empty-string login."""
+    SMTPMailer('smtp.example.com', security='none').send(make_message())
+
+    assert recording_smtp.instances[0].login_args is None
+
+
+@pytest.mark.parametrize('failure', [
+    smtplib.SMTPAuthenticationError(535, b'auth failed'),
+    smtplib.SMTPRecipientsRefused({'invitee@example.com': (550, b'no such user')}),
+    smtplib.SMTPServerDisconnected('connection reset'),
+    TimeoutError('timed out'),
+    ConnectionRefusedError('nothing listening'),
+])
+def test_every_transport_fault_becomes_a_mail_error(recording_smtp, monkeypatch, failure):
+    """Callers catch MailError and nothing else; a raw smtplib fault escaping is the bug."""
+    def explode(self, message):
+        raise failure
+    monkeypatch.setattr(recording_smtp, 'send_message', explode)
+
+    with pytest.raises(MailError):
+        SMTPMailer('smtp.example.com', security='none').send(make_message())
+
+
+def test_mail_error_chains_the_original_fault(recording_smtp, monkeypatch):
+    """The relay's own words survive on __cause__, so a failure is still diagnosable."""
+    def explode(self, message):
+        raise smtplib.SMTPAuthenticationError(535, b'Application-specific password required')
+    monkeypatch.setattr(recording_smtp, 'send_message', explode)
+
+    with pytest.raises(MailError) as caught:
+        SMTPMailer('smtp.example.com', security='none').send(make_message())
+
+    assert isinstance(caught.value.__cause__, smtplib.SMTPAuthenticationError)
+
+
+def test_smtp_mailer_never_logs_the_body(recording_smtp, caplog):
+    """The invite token lives in the body; a copy in a log file is a copy of the credential."""
+    caplog.set_level('DEBUG')
+
+    SMTPMailer('smtp.example.com', security='none').send(make_message())
+
+    assert 'SECRET-TOKEN' not in caplog.text
+    assert 'invitee@example.com' in caplog.text  # recipient is fine, and useful
+
+
+def test_failed_send_does_not_log_the_body(recording_smtp, monkeypatch, caplog):
+    """Especially not on the error path, which is the one that reaches a bug tracker."""
+    caplog.set_level('DEBUG')
+
+    def explode(self, message):
+        raise smtplib.SMTPDataError(554, b'rejected')
+    monkeypatch.setattr(recording_smtp, 'send_message', explode)
+
+    with pytest.raises(MailError) as caught:
+        SMTPMailer('smtp.example.com', security='none').send(make_message())
+
+    assert 'SECRET-TOKEN' not in caplog.text
+    assert 'SECRET-TOKEN' not in str(caught.value)
+
+
+# ── The other backends ─────────────────────────────────────────────────────
+
+def test_console_mailer_renders_the_link(caplog):
+    """ConsoleMailer's console *is* the mailbox — an unclickable link makes it useless."""
+    caplog.set_level('DEBUG')
+
+    ConsoleMailer().send(make_message())
+
+    assert 'SECRET-TOKEN' in caplog.text
+
+
+def test_null_mailer_discards_without_raising():
+    assert NullMailer().send(make_message()) is None
+
+
+def test_memory_mailer_captures_recipient_subject_and_both_parts():
+    backend = MemoryMailer()
+    backend.send(make_message())
+
+    assert len(backend.outbox) == 1
+    message = backend.outbox[0]
+    assert message['To'] == 'invitee@example.com'
+    assert message['Subject'] == 'You have been invited to PixelVault'
+    assert message.get_content_type() == 'multipart/alternative'
+    parts = {p.get_content_type(): p.get_content() for p in message.iter_parts()}
+    assert 'SECRET-TOKEN' in parts['text/plain']
+    assert 'SECRET-TOKEN' in parts['text/html']
+
+
+# ── The extensions proxy ───────────────────────────────────────────────────
+
+def test_app_gets_a_backend_at_boot(app):
+    """create_app() must leave a usable mailer behind, as it does for db and limiter."""
+    from pixelvault.mailer import Mailer
+
+    assert isinstance(app.extensions['mailer'], Mailer)
+
+
+def test_proxy_delegates_to_the_swapped_in_backend(app, mailer):
+    """The `mailer` fixture is what every later invite test asserts against."""
+    from pixelvault.extensions import mailer as proxy
+
+    with app.app_context():
+        proxy.send(make_message())
+        assert proxy.backend is mailer
+
+    assert len(mailer.outbox) == 1
+
+
+# ── Boot-time configuration validation ─────────────────────────────────────
+
+@pytest.fixture
+def mail_config(monkeypatch):
+    """Rebind the mail constants ``_validate_mail_config`` reads, for one test.
+
+    They live on the ``pixelvault`` package namespace, not on ``config``, because
+    ``__init__.py`` pulls them in with ``from .config import *`` — so that is where
+    the function resolves them.
+    """
+    def _set(**values):
+        for name, value in values.items():
+            monkeypatch.setattr(pixelvault, name, value)
+    return _set
+
+
+def test_unconfigured_mail_still_boots(mail_config):
+    """A dev checkout with no relay must not be blocked from starting."""
+    mail_config(MAIL_ENABLED=True, SMTP_HOST='', MAIL_FROM='', PUBLIC_BASE_URL='')
+    pixelvault._validate_mail_config()
+
+
+def test_smtp_without_mail_from_fails_loudly(mail_config):
+    mail_config(MAIL_ENABLED=True, SMTP_HOST='smtp.example.com',
+                SMTP_SECURITY='starttls', MAIL_FROM='', PUBLIC_BASE_URL='https://vault.test.invalid')
+
+    with pytest.raises(RuntimeError, match='MAIL_FROM'):
+        pixelvault._validate_mail_config()
+
+
+def test_smtp_without_public_base_url_fails_loudly(mail_config):
+    """Otherwise the invite arrives carrying a link to nowhere — a failure at read time, hours later."""
+    mail_config(MAIL_ENABLED=True, SMTP_HOST='smtp.example.com',
+                SMTP_SECURITY='starttls', MAIL_FROM='bot@example.com', PUBLIC_BASE_URL='')
+
+    with pytest.raises(RuntimeError, match='PUBLIC_BASE_URL'):
+        pixelvault._validate_mail_config()
+
+
+def test_bad_security_mode_fails_loudly(mail_config):
+    mail_config(MAIL_ENABLED=True, SMTP_HOST='smtp.example.com', SMTP_SECURITY='tls',
+                MAIL_FROM='bot@example.com', PUBLIC_BASE_URL='https://vault.test.invalid')
+
+    with pytest.raises(RuntimeError, match='SMTP_SECURITY'):
+        pixelvault._validate_mail_config()
+
+
+def test_disabled_mail_is_never_incoherent(mail_config):
+    """MAIL_ENABLED=false sends nothing, so half-filled SMTP settings cannot hurt anyone."""
+    mail_config(MAIL_ENABLED=False, SMTP_HOST='smtp.example.com', SMTP_SECURITY='nonsense',
+                MAIL_FROM='', PUBLIC_BASE_URL='')
+    pixelvault._validate_mail_config()
+
+
+# ── Config normalisation ───────────────────────────────────────────────────
+
+def test_public_base_url_has_no_trailing_slash():
+    """Link building downstream concatenates a path; a trailing slash would double it."""
+    from pixelvault.config import PUBLIC_BASE_URL
+
+    assert not PUBLIC_BASE_URL.endswith('/')


### PR DESCRIPTION
Closes #7.

Registration becomes link-only. An admin adds an address, the app mints a single-use, TTL-bounded invite and emails it, and following that link is the only way an account comes into existence. `/register` is gone.

## What changed

`AllowedEmail` stops being a passive whitelist and becomes a credential with a lifecycle — issued → sent → accepted / expired / revoked — and the app acquires its first outbound side effect, SMTP. Both got their own modules rather than more code inside route handlers, following the `uploads.py` / `routes/share.py` split the repo already uses:

| Module | Concern |
|---|---|
| `mailer.py` | Transport. Has never heard of invites, so the next feature needing email is free and a relay migration is one config change. |
| `emails.py` | Content. Renders the invitation's text and HTML parts. |
| `invites.py` | Lifecycle. No Flask imports; the whole flow is drivable from a test with no HTTP client. |

Routes: `GET /invite/<token>` validates and redirects, `GET|POST /invite` render and accept, and the admin panel gains resend and copy-link alongside issue-on-add.

## The properties worth reviewing for

- **The email address comes from the invite row and from nowhere else.** The acceptance form's email field has no `name` attribute and `invites.consume` reads the address off the row. Without this the whitelist means nothing, because the holder of a link would pick the address it authorizes.
- **Tokens are hashed at rest** (SHA-256 of `secrets.token_urlsafe(32)`). Neither a database backup nor a screenshot of the admin panel holds a working credential. The accepted cost: a link can never be re-shown, so renewal *mints* — which is why resend and copy-link both kill the previous link.
- **Single-use**, enforced by nulling `token_hash` in the same transaction as user creation. A racing second acceptance is stopped by the unique index on `user.email`, which works precisely because both racers necessarily agree on the address.
- **The token leaves the URL immediately** — validated, stashed in the signed session, redirected. `Referrer-Policy` already stopped cross-origin leaks, but a token in the path still lands in nginx access logs and browser history.
- **Links are built from `PUBLIC_BASE_URL`, never the request `Host`**, so a spoofed header on the add-email request cannot steer a real invite at a domain the attacker owns. There is a test that performs that attack rather than merely arguing about it.
- **Accepting while signed in is refused, not merged.** Logging the visitor out is a side effect any stranger could trigger in someone else's browser.

## SMTP is optional

Copy-link rotates and shows the URL once without sending anything, so a self-hoster with no relay — or an admin whose invite landed in a spam folder — still has a way to hand the link over. With no `SMTP_HOST` set the app uses `ConsoleMailer` and prints the invitation to the log, which is how a dev checkout completes the flow.

## Deploy notes

- Every pre-existing `allowed_email` row reads as **no invite** and cannot be used to register until an admin presses *Send invite*. Nothing is emailed on upgrade — mailing a year-old list on deploy day is a good way to get a sending domain blocked.
- Migration is ten additive `ALTER TABLE` statements plus one index, applied by `_run_migrations()` on boot.
- Thirteen new environment variables, all wired through both compose files. `PUBLIC_BASE_URL` and `MAIL_FROM` become required once `SMTP_HOST` is set, and `create_app()` refuses to boot without them.

## Tests

345 pass. Six new modules cover the mailer, the state machine, the lifecycle, the composed email, the admin panel and access control — including the email-override attack, replayed and expired tokens, and that `/register` returns 404 rather than redirecting.

## Docs

`docs/registration_invites.md` is the operator guide (inviting, the panel's buttons, mail troubleshooting); `docs/invite_registration_design.md` carries the design and its rationale; `docs/configuration.md` documents every variable.

## Security review

Reviewed for authentication bypass, privilege escalation, injection, XSS and data exposure, with the authorization claims verified by probe rather than by reading: no account is creatable without a live invite, the form cannot set `is_admin` or override the email, all four admin invite routes return 403 to an authenticated non-admin, and no plaintext token reaches the database. No high or medium findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
